### PR TITLE
CP-578: Add common bash config and functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-.idea/
-*.iml
+# Build products
+target/
 
+# IntelliJ data
+*.iml
+.idea/
+.ipr

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,3 +50,5 @@ RUN apt update \
 
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
+
+COPY include/etc/confluent/docker /etc/confluent/docker

--- a/base/include/etc/confluent/docker/bash-config
+++ b/base/include/etc/confluent/docker/bash-config
@@ -1,0 +1,28 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset \
+    -o errexit
+
+# Trace may expose passwords/credentials by printing them to stdout, so turn on with care.
+if [ "${TRACE:-}" == "true" ]; then
+  set -o verbose \
+      -o xtrace
+fi
+
+
+function show_env {
+    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG'
+}


### PR DESCRIPTION
They will be used in downstream projects, like ksql, to simplify and
unify the configuration and common functions.

See related https://github.com/confluentinc/cp-docker-images/pull/606