### PR TITLE
CPKAFKA-2291: Fix NPE in TopicEnsure for unknown configs in TopicSpec.config

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/TopicEnsure.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/TopicEnsure.java
@@ -18,6 +18,7 @@ package io.confluent.kafkaensure;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
@@ -72,7 +73,10 @@ public class TopicEnsure {
     // Create actual TopicSpec.
     Map<String, String> actualConfig = new HashMap<>();
     for (Map.Entry<String, String> entry : spec.config().entrySet()) {
-      actualConfig.put(entry.getKey(), config.get(entry.getKey()).value());
+      ConfigEntry actualConfigEntry = config.get(entry.getKey());
+      if (actualConfigEntry != null) {
+        actualConfig.put(entry.getKey(), actualConfigEntry.value());
+      }
     }
 
     TopicSpec actualSpec = new TopicSpec(
@@ -83,7 +87,7 @@ public class TopicEnsure {
     boolean isTopicValid = actualSpec.equals(spec);
     if (!isTopicValid) {
       System.err.printf(
-          "Invalid topic [ %s ] ! Expected %s but got %s", spec.name(), spec, actualSpec
+          "Invalid topic [ %s ] ! Expected %s but got %s\n", spec.name(), spec, actualSpec
       );
     }
 

--- a/utility-belt/src/test/java/io/confluent/admin/utils/TopicEnsureTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/TopicEnsureTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafkaensure;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.TopicConfig;
+import io.confluent.kafkaensure.TopicSpec;
+
+import io.confluent.admin.utils.EmbeddedKafkaCluster;
+
+public class TopicEnsureTest {
+
+  private static final int NUM_BROKERS = 3;
+  private static final int NUM_ZK = 3;
+  private static final int DEFAULT_PARTITIONS = 2;
+  private static final int DEFAULT_REPLICATION_FACTOR = 3;
+  private static final Integer TIMEOUT_MS = 20000;
+
+  private static EmbeddedKafkaCluster kafka;
+  private static TopicEnsure topicEnsure;
+
+  @Before
+  public void setUp() throws IOException {
+    kafka = new EmbeddedKafkaCluster(NUM_BROKERS, NUM_ZK);
+    kafka.start();
+
+    Properties adminClientProps = new Properties();
+    adminClientProps.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                         kafka.getBootstrapBroker(SecurityProtocol.PLAINTEXT));
+    topicEnsure = new TopicEnsure(adminClientProps);
+  }
+
+  @After
+  public void tearDown() {
+    kafka.shutdown();
+  }
+
+  @Test
+  public void testCreateExistsValidateTopic() throws Exception {
+    final TopicSpec spec = simpleTopicSpec("test-topic");
+    topicEnsure.createTopic(spec, TIMEOUT_MS);
+
+    assertTrue(topicEnsure.topicExists(spec, TIMEOUT_MS));
+    assertTrue(topicEnsure.validateTopic(spec, TIMEOUT_MS));
+  }
+
+  @Test
+  public void testValidateTopicWithBadConfigEntry() throws Exception {
+    final String topicName = "another-topic";
+    Map<String, String> topicProps = new HashMap<>();
+    topicProps.put(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2");
+    TopicSpec spec = new TopicSpec(topicName, 2, 3, topicProps);
+    topicEnsure.createTopic(spec, TIMEOUT_MS);
+
+    topicProps.put("incorrect.config", "1");
+    assertFalse(topicEnsure.validateTopic(spec, TIMEOUT_MS));
+  }
+
+  @Test
+  public void testTopicExistsForNonexistentTopic() throws Exception {
+    assertFalse(topicEnsure.topicExists(simpleTopicSpec("unknown-topic"), TIMEOUT_MS));
+  }
+
+  @Test(expected = Exception.class)
+  public void testValidateNonexistentTopic() throws Exception {
+    assertFalse(topicEnsure.validateTopic(simpleTopicSpec("unknown-topic"), TIMEOUT_MS));
+  }
+
+  @Test
+  public void testValidateTopicWithNonMatchingSpec() throws Exception {
+    final String topicName = "test-topic";
+    topicEnsure.createTopic(simpleTopicSpec(topicName), TIMEOUT_MS);
+
+    TopicSpec spec = new TopicSpec(topicName, 1, DEFAULT_REPLICATION_FACTOR, simpleTopicProps());
+    assertFalse(topicEnsure.validateTopic(spec, TIMEOUT_MS));
+
+    TopicSpec spec2 = new TopicSpec(topicName, DEFAULT_PARTITIONS, 1, simpleTopicProps());
+    assertFalse(topicEnsure.validateTopic(spec2, TIMEOUT_MS));
+
+    // same spec but with empty config map is ok -- will not validate config entries
+    TopicSpec spec3 = new TopicSpec(
+        topicName, DEFAULT_PARTITIONS, DEFAULT_REPLICATION_FACTOR, Collections.emptyMap());
+    assertTrue(topicEnsure.validateTopic(spec3, TIMEOUT_MS));
+  }
+
+  private static TopicSpec simpleTopicSpec(String topic) {
+    return new TopicSpec(topic, DEFAULT_PARTITIONS, DEFAULT_REPLICATION_FACTOR, simpleTopicProps());
+  }
+
+  private static Map<String, String> simpleTopicProps() {
+    return Collections.singletonMap(TopicConfig.MIN_IN_SYNC_REPLICAS_CONFIG, "2");
+  }
+}


### PR DESCRIPTION
TopicEnsure before this PR running against brokers with older CP version:
Scenario 1) TopicSpec contains "min.insync.replicas" config. TopicEnsure.validateTopic() returns true if config value matches and false otherwise.
Scenario 2) TopicSpec contains config with a typo (e.g, "min.insync.replica"). TopicEnsure.validateTopic() NPEs.

The newer broker interceptor filters out some topic configs before responding to AdminClient.describeConfigs(), including "min.insync.replicas", which causes NPE in Scenario 1.

This PR proposes the following behavior (if TopicEnsure is called against brokers with the recent broker interceptor):
Scenario 1) TopicSpec contains "min.insync.replicas" config. TopicEnsure.validateTopic() returns false.
Scenario 2)  TopicSpec contains config with a typo (e.g, "min.insync.replica").  TopicEnsure.validateTopic() returns false.

The result of this PR: We will need to remove "min.insync.replicas" configs from topic.yaml.template files in CCloud services that validate topics. We already set the default for "min.insync.replicas" to 2 in CCloud + our topic policy ensures that all newly created topics have min insync replicas set to 2. So, the additional check for this particular config does not add anything. 
