### PR TITLE
MINOR: Pin Sphinx<2.0.0 to maintain py27 compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-docker_oraclejdk8 {
+dockerfile {
     upstreamProjects = ['confluentinc/common']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
     dockerRepos = ['confluentinc/cp-base']

--- a/base/tox.ini
+++ b/base/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest
     pytest-xdist
     pytest-cov
-    sphinx!=1.2b2
+    sphinx!=1.2b2,<2.0.0
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True


### PR DESCRIPTION
Eventually we will want to unpin this, but we need to retire py27 generally before we do that.

Also fixes the Jenkinsfile to move away from the deprecated docker_oraclejdk8 name.