### PR TITLE
Fix compilation error due to changed signature of test util

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
@@ -71,6 +71,8 @@ public class EmbeddedKafkaCluster {
   private static final boolean ENABLE_SSL = false;
   private static final int SSL_PORT = 0;
   private static final int SASL_SSL_PORT_BASE = 49092;
+  private static final int NUM_PARTITIONS = 1;
+  private static final short DEFAULT_REPLICATION_FACTOR = 1;
   private static Option<Properties> brokerSaslProperties = Option$.MODULE$.<Properties>empty();
   private static MiniKdc kdc;
   private static File trustStoreFile;
@@ -349,7 +351,9 @@ public class EmbeddedKafkaCluster {
             SASL_SSL_PORT_BASE + brokerId,
             Option.<String>empty(),
             1,
-            false
+            false,
+            NUM_PARTITIONS,
+            DEFAULT_REPLICATION_FACTOR
         );
 
     KafkaServer broker = TestUtils.createServer(KafkaConfig.fromProps(props), new MockTime());


### PR DESCRIPTION
https://github.com/apache/kafka/commit/8e161580b859b2fcd54c59625e232b99f3bb48d0 changed the signature of `TestUtils.createBrokerConfig`. This change fixes the call here to reflect that change.