### PR TITLE
pin pytest versions

### DIFF
--- a/base/tox.ini
+++ b/base/tox.ini
@@ -6,9 +6,9 @@ toxworkdir = /var/tmp
 deps =
     -rrequirements.txt
     flake8
-    pytest
-    pytest-xdist
-    pytest-cov
+    pytest == 4.6.4
+    pytest-xdist == 1.29.0
+    pytest-cov == 2.7.1
     sphinx!=1.2b2,<2.0.0
 install_command = pip install -U {packages}
 recreate = True


### PR DESCRIPTION
pin pytest versions since pytest 5.0.0 do not support python 2.7 anymore. Target from 4.0.x branch.