### PR TITLE
Add basic support for Kafka named listeners

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/ClusterStatus.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/ClusterStatus.java
@@ -435,11 +435,19 @@ public class ClusterStatus {
     }.getType();
     Map<String, Object> parsedBroker = gson.fromJson(broker, type);
 
+    Map<String, String> securityProtocolMap =
+        (Map<String, String>) parsedBroker.get("listener_security_protocol_map");
     for (String rawEndpoint : (List<String>) parsedBroker.get("endpoints")) {
       String[] protocolAddress = rawEndpoint.split("://");
 
       String protocol = protocolAddress[0];
       String address = protocolAddress[1];
+
+      // If the security protocol map is available, map the listener name to its protocol
+      if (securityProtocolMap != null) {
+        protocol = securityProtocolMap.get(protocol);
+      }
+
       endpointMap.put(protocol, address);
     }
     return endpointMap;


### PR DESCRIPTION
Previously, cluster readiness checks fail if the Kafka brokers use named
listeners with a custom security protocol map.

The broker's security protocol map is now used to map the listener name
to the security protocol name. If multiple listeners share the same
security protocol, only the last one is used.

Fixes confluentinc/schema-registry#648