### PR TITLE
Fix compilation with zookeeper 3.5.5

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
@@ -69,6 +69,9 @@ public class EmbeddedZookeeperEnsemble {
   }
 
   private void initialize() throws IOException {
+    // org.apache.zookeeper.test.ClientBase relies on 4lw and the whitelist only contains `srvr`
+    // in ZooKeeper 3.5.3 and later (it was less restrictive in previous versions)
+    System.setProperty("zookeeper.4lw.commands.whitelist", "*");
     HashMap peers = new HashMap();
     for (int i = 0; i < numNodes; i++) {
 
@@ -119,6 +122,7 @@ public class EmbeddedZookeeperEnsemble {
       s.start();
     }
 
+    System.out.println("Checking ports " + hostPort);
     log.info("Checking ports " + hostPort);
 
     for (String hp : hostPort.split(",")) {

--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
@@ -16,6 +16,7 @@
 package io.confluent.admin.utils;
 
 import org.apache.zookeeper.client.FourLetterWordMain;
+import org.apache.zookeeper.common.X509Exception.SSLContextException;
 import org.apache.zookeeper.server.quorum.Election;
 import org.apache.zookeeper.server.quorum.QuorumPeer;
 import org.apache.zookeeper.test.ClientBase;
@@ -76,9 +77,8 @@ public class EmbeddedZookeeperEnsemble {
 
       peers.put(Long.valueOf(i), new QuorumPeer.QuorumServer(
           Long.valueOf(i).longValue(),
-          LOCAL_ADDR,
-          port + 1000,
-          portLE + 1000,
+          new InetSocketAddress(LOCAL_ADDR, port + 1000),
+          new InetSocketAddress(LOCAL_ADDR, portLE + 1000),
           QuorumPeer.LearnerType.PARTICIPANT
       ));
     }
@@ -132,7 +132,7 @@ public class EmbeddedZookeeperEnsemble {
       log.info(hp + " is accepting client connections");
       try {
         log.info(send4LW(hp, CONNECTION_TIMEOUT, "stat"));
-      } catch (TimeoutException e) {
+      } catch (TimeoutException | SSLContextException e) {
         log.error(e.getMessage(), e);
       }
 
@@ -142,12 +142,12 @@ public class EmbeddedZookeeperEnsemble {
     isRunning = true;
   }
 
-  public String send4LW(String hp, long timeout, String FourLW) throws TimeoutException {
+  public String send4LW(String hp, long timeout, String FourLW) throws TimeoutException, SSLContextException {
     long start = System.currentTimeMillis();
 
     while (true) {
       try {
-        HostPort e = (HostPort) parseHostPortList(hp).get(0);
+        HostPort e = parseHostPortList(hp).get(0);
         String result = FourLetterWordMain.send4LetterWord(e.host, e.port, FourLW);
         return result;
       } catch (IOException var7) {

--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
@@ -122,7 +122,6 @@ public class EmbeddedZookeeperEnsemble {
       s.start();
     }
 
-    System.out.println("Checking ports " + hostPort);
     log.info("Checking ports " + hostPort);
 
     for (String hp : hostPort.split(",")) {


### PR DESCRIPTION
And whitelist 4lw commands in tests (necessary since ZK 3.5.3).