### PR TITLE
add mesos-setup.sh back

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -44,7 +44,7 @@ COPY requirements.txt .
 
 RUN microdnf install yum \
     && yum update -q -y \
-    && yum install -y git wget nc python3 gcc libffi-devel redhat-rpm-config python3-devel openssl-devel make tar procps \
+    && yum install -y git wget nc python3 gcc libffi-devel redhat-rpm-config python3-devel openssl-devel make tar procps krb5-workstation \
     && pip3 install --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && mkdir -p /usr/lib/jvm \
     && cd /usr/lib/jvm \

--- a/base/include/etc/confluent/docker/mesos-setup.sh
+++ b/base/include/etc/confluent/docker/mesos-setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set +o nounset
+
+if [ -z $SKIP_MESOS_AUTO_SETUP ]; then
+    if [ -n $MESOS_SANDBOX ] && [ -e $MESOS_SANDBOX/.ssl/scheduler.crt ] && [ -e $MESOS_SANDBOX/.ssl/scheduler.key ]; then
+        echo "Entering Mesos auto setup for Java SSL truststore. You should not see this if you are not on mesos ..."
+
+        openssl pkcs12 -export -in $MESOS_SANDBOX/.ssl/scheduler.crt -inkey $MESOS_SANDBOX/.ssl/scheduler.key \
+                       -out /tmp/keypair.p12 -name keypair \
+                       -CAfile $MESOS_SANDBOX/.ssl/ca-bundle.crt -caname root -passout pass:export
+
+        keytool -importkeystore \
+                -deststorepass changeit -destkeypass changeit -destkeystore /tmp/kafka-keystore.jks \
+                -srckeystore /tmp/keypair.p12 -srcstoretype PKCS12 -srcstorepass export \
+                -alias keypair
+
+        keytool -import \
+                -trustcacerts \
+                -alias root \
+                -file $MESOS_SANDBOX/.ssl/ca-bundle.crt \
+                -storepass changeit \
+                -keystore /tmp/kafka-truststore.jks -noprompt
+    fi
+fi
+
+set -o nounset


### PR DESCRIPTION
The old cp-docker-image have that file in base image, some images is using it, we should add it back.
Also there is krb client setup on old base image, we might want to it back either.