### PR TITLE
ST-2548: Adding iputils which includes ping to the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -44,7 +44,7 @@ COPY requirements.txt .
 
 RUN microdnf install yum \
     && yum update -q -y \
-    && yum install -y git wget nc python3 gcc libffi-devel redhat-rpm-config python3-devel openssl-devel make tar procps krb5-workstation \
+    && yum install -y git wget nc python3 gcc libffi-devel redhat-rpm-config python3-devel openssl-devel make tar procps krb5-workstation iputils\
     && pip3 install --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && mkdir -p /usr/lib/jvm \
     && cd /usr/lib/jvm \


### PR DESCRIPTION
The rhel base image is missing ping. This will install iputils to the base image which includes ping.