### PR TITLE
ST-2560: Explicitly set python-dateutil to version 2.8.0

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,2 @@
+python-dateutil==2.8.0
 git+https://github.com/confluentinc/confluent-docker-utils@v0.0.34


### PR DESCRIPTION
When building the base image we install the confluent-docker-utils module which requires boto which requires python-dateutil. For some reason there is an issue with the python-dateutil module because when it goes to install the latest version 2.8.1 something gets messed up and it reports that it is installing version None, and then when running dub which depends on that module it fails saying the module can not be found. If we explicitly try and install version 2.8.1 we get the same issue, so there must be an issue with that package on our pypi server or something to that affect. If we explicitly install python-dateutil 2.8.0 prior to installing confluent-docker-utils then it installs correctly and everything works.