### PR TITLE
update pom for docker-utils to include utility-belt dependency

### DIFF
--- a/docker-utils/pom.xml
+++ b/docker-utils/pom.xml
@@ -35,6 +35,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>utility-belt</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j-api.version}</version>


### PR DESCRIPTION
Currently images are failing as they are not able to access zk-ready and kafka-ready.  These are part of utility belt and the base image only includes docker-utils.  Adding the dependency.