### PR TITLE
Skipmvn

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,4 +6,5 @@ dockerfile {
       'confluentinc/cp-kerberos']
     slackChannel = '#tools-notifications'
     upstreamProjects = ['confluentinc/confluent-docker-utils', 'confluentinc/common']
+    mvnSkipDeploy = true
 }


### PR DESCRIPTION
When building images we do not want to run maven deploy because there are not maven artifacts to publish and we push the docker images in a separate step.