### PR TITLE
Use docker swarm nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    nodeLabel = 'docker-oraclejdk8-compose'
+    nodeLabel = 'docker-oraclejdk8-compose-swarm'
     dockerPush = true
     usePackages = true
     dockerRepos = ['confluentinc/cp-base-new', 'confluentinc/cp-base',


### PR DESCRIPTION
We should be using the new docker swarm nodes because the pool is much bigger.