### PR TITLE
Disable cron schedule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,5 @@ dockerfile {
     slackChannel = '#tools-notifications'
     upstreamProjects = ['confluentinc/confluent-docker-utils', 'confluentinc/common']
     mvnSkipDeploy = true
+    cron = ''
 }


### PR DESCRIPTION
I am disabling the cron schedule because it will always fail because these builds require parameters to be passed in.