### PR TITLE
Remove upstream job dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ dockerfile {
     dockerRepos = ['confluentinc/cp-base-new', 'confluentinc/cp-base',
       'confluentinc/cp-jmxterm', 'confluentinc/cp-kerberos']
     slackChannel = '#tools-notifications'
-    upstreamProjects = ['confluentinc/confluent-docker-utils', 'confluentinc/common']
     mvnSkipDeploy = true
     cron = ''
 }


### PR DESCRIPTION
The common-docker repo now depends on the packaging build, so anytime the upstream dependencies that were listed in here triggered this build it would fail because they don't and can't provide the necessary build parameters. So I am removing these upstream dependencies so we stop getting a bunch of failed builds.