### PR TITLE
ST-2731: Do not add packaging debian repository to old base image

### DIFF
--- a/base-deb8/Dockerfile
+++ b/base-deb8/Dockerfile
@@ -82,10 +82,7 @@ RUN echo "===> Updating debian ....." \
     && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
     && echo "===> Installing Kerberos Patch ..." \
     && DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user \
-    && rm -rf /var/lib/apt/lists/* \
-    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - ; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list
+    && rm -rf /var/lib/apt/lists/*
 
 ENV CUB_CLASSPATH=/etc/confluent/docker/docker-utils.jar
 COPY include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
The debian packaging repository gets added in each of the docker image so we don't need to add it in the base image as well. This is throwing warnings in our builds that the repository was added twice.