### PR TITLE
ST-2791: Install python modules from binary packages and remove packages installed only for building python modules

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -69,11 +69,10 @@ RUN echo "===> Updating debian ....." \
                 wget \
                 netcat \
                 python=${PYTHON_VERSION} \
-                build-essential libssl-dev libffi-dev python-dev \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --only-binary --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -40,8 +40,8 @@ ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 COPY requirements.txt .
 
 RUN apt update \
-    && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 build-essential libssl-dev libffi-dev python-dev\
-    && pip install --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
+    && pip install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \

--- a/base/Dockerfile.rhel8
+++ b/base/Dockerfile.rhel8
@@ -44,8 +44,8 @@ COPY requirements.txt .
 
 RUN microdnf install yum \
     && yum update -q -y \
-    && yum install -y git wget nc python3 gcc libffi-devel redhat-rpm-config python3-devel openssl-devel make tar procps krb5-workstation iputils\
-    && pip3 install --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && yum install -y git wget nc python3 tar procps krb5-workstation iputils\
+    && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
     && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
     && yum -y install ${ZULU_OPENJDK} \


### PR DESCRIPTION
Previously added python modules that are required by dub were built from source. In order to build them from source it required additional packages to be installed. Those additional packages made a significant increase in the size of the base images. By installing the python modules from a binary distribution we don't need those additional packages installed so the image size does not increase nearly as much. The Jira ticket has a lot more details on this.

I tested this by building all three docker images locally and then running the ksql-images build to verify it still works. The ksql-images build was previously failing when these new python modules were not installed. I also verified the size of the new docker images. There is still a small increase in the image size vs. the 5.3.x image, but that is due to the new python modules that were added, and those are required by the new version of docker compose that is used by the dub utility.

Eli-Smagas-MBP15:common-docker eli$ docker image ls|grep cp-base-new
368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new                    dub-rhel8            66f745dd0e73        6 minutes ago       537MB
368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new                    dub-deb8             6bed64282a67        14 minutes ago      529MB
368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new                    dub-deb9             8ed7249547a6        50 minutes ago      532MB
368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new                    5.3.x-latest         d787bc7ff646        11 hours ago        454MB
368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new                    5.4.x-latest         e074781404f6        14 hours ago        711MB