### PR TITLE
ST-2560: Adding licenses to rhel image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -67,5 +67,8 @@ ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/sha
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 
+RUN mkdir /licenses
+COPY license.txt /licenses
+
 USER appuser
 WORKDIR /home/appuser

--- a/base/license.txt
+++ b/base/license.txt
@@ -1,0 +1,1 @@
+Copyright 2020 Confluent, Inc.


### PR DESCRIPTION
In order to pass the redhat container registry scan we need to have a licenses folder with a license in it. Since we haven't decided on the license we want to use I am creating the folder and copying the apache license that we already have in this repo. I think we will end up using this license in the end because the license is only for the image build and not the other software we install. Since the CP packages we install already have licenses those will apply for those products, and this just applies to the docker file.