### PR TITLE
ST-2560: Adding instructions for building with packages to the readme file.

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -18,6 +18,7 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *docker.test-registry*: (Optional) Registry to pull test dependency images from. Trailing `/` is required. Used as `DOCKER_TEST_REGISTRY` during testing. Defaults to the value of `docker.upstream-registry`.
 - *docker.test-tag*: (Optional) Use the given tag when pulling test dependency images. Used as `DOCKER_TEST_TAG` during testing. Defaults to the value of `docker.upstream-tag`.
 - *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `deb8`, `deb9`, and `ubi8`. Default value is `deb8`.
+- *CONFLUENT_VERSION*: (Required) Specify the full Confluent Platform release version. Example: 5.4.0
 
 
 ## Building


### PR DESCRIPTION
I am updating the readme to include a description of the two arguments required to build the images using the packages from the s3 repo.