### PR TITLE
ST-2952: Setting default python to python3 in ubi8 image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -50,6 +50,7 @@ COPY requirements.txt .
 RUN microdnf install yum \
     && yum update -q -y \
     && yum install -y git wget nc python3 tar procps krb5-workstation iputils \
+    && alternatives --set python /usr/bin/python3 \
     && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
     && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \


### PR DESCRIPTION
This will set the default python version to python3. So when you just run python now it will work and use the installed version of python3. I tested this by building the docker image locally, starting a container from that image and running python to make sure it worked.