### PR TITLE
ST-2963: Creating /usr/logs/ folder as appuser in ubi8 image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -59,9 +59,9 @@ RUN microdnf install yum \
     && yum clean all \
     && rm -rf /tmp/* \
     && rm -f requirements.txt \
-    && mkdir -p /etc/confluent/docker \
+    && mkdir -p /etc/confluent/docker /usr/logs \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && chown appuser:appuser -R /etc/confluent/
+    && chown appuser:appuser -R /etc/confluent/ /usr/logs
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/


### PR DESCRIPTION
We need to create the /usr/logs folder in the ubi8 image because some of our apps want to write to that folder and they can not create it because /usr is owned by root and we are now running as appuser. This will create the /usr/logs folder and assign ownership of it to the appuser