### PR TITLE
ST-2950: Upgrading jdk to zulu-11-11.37+17-1 in the ubi8 base image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -43,7 +43,7 @@ ENV LANG="C.UTF-8"
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
 # Zulu openJDK
-ENV ZULU_OPENJDK="zulu-8-8.40.0.25"
+ENV ZULU_OPENJDK="zulu-11-11.37+17-1"
 
 COPY requirements.txt .
 


### PR DESCRIPTION
For the 6.0.0 release we are going to run JDK11 in our docker images. This upgrades the ubi8 base image to JDK11, but not the debian images because we are supposed to deprecate them in the 6.0.0 release.