### PR TITLE
ST-2950: Downgrading ubi8 to jdk 11.0.5+10 because of issue withe 11.0.6

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -43,7 +43,7 @@ ENV LANG="C.UTF-8"
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
 # Zulu openJDK
-ENV ZULU_OPENJDK="zulu-11-11.37+17-1"
+ENV ZULU_OPENJDK="zulu-11-11.35+15-1"
 
 COPY requirements.txt .
 


### PR DESCRIPTION
Downgrading to version 11.0.5 because the 11.0.6 version introduced a change that causes an issue with our products. Details about the issue are in the ticket ST-2950 and https://confluentinc.atlassian.net/browse/ESCALATION-2286