### PR TITLE
ST-3165: Using explicit python3 version in ubi image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -45,11 +45,13 @@ ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 # Zulu openJDK
 ENV ZULU_OPENJDK="zulu-8-8.40.0.25"
 
+ENV PYTHON_VERSION="36-3.6.8"
+
 COPY requirements.txt .
 
 RUN microdnf install yum \
     && yum update -q -y \
-    && yum install -y git wget nc python3 tar procps krb5-workstation iputils \
+    && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils \
     && alternatives --set python /usr/bin/python3 \
     && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \


### PR DESCRIPTION
This will make so we install python 3.6.8 so that we can reproduce the base image with that exact version instead of always getting the latest python 3 version.