### PR TITLE
ST-3255: Set parameter to always pull latest version of the os base image when building cp-base-new

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -36,6 +36,7 @@
     <properties>
         <docker.skip-build>false</docker.skip-build>
         <docker.skip-test>false</docker.skip-test>
+        <docker.pull-image>true</docker.pull-image>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This will enable the new parameter to always pull down the OS base image instead of using a local version.