### PR TITLE
bump confluent-docker-utils

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,2 +1,2 @@
 python-dateutil==2.8.0
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.36
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.37


### PR DESCRIPTION
# what
Bump confluent-docker-utils to have the fix https://github.com/confluentinc/confluent-docker-utils/pull/16

Not sure if we should apply the same fix for cp-docker-images? https://github.com/confluentinc/cp-docker-images/blob/5.3.1-post/debian/base/Dockerfile#L83 Seems they share different versions.