### PR TITLE
ST-3334: Install hostname app in ubi8 base image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -51,7 +51,7 @@ COPY requirements.txt .
 
 RUN microdnf install yum \
     && yum update -q -y \
-    && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils \
+    && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
     && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \


### PR DESCRIPTION
We need to install the hostname utility on the ubi8 docker images because other images require it, such as zookeeper when it starts up.