### PR TITLE
ST-3476: Set ubi8 base image to version 8.1-408

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
Use version 8.1-408 of the ubi8-minimal image because the latest version has a bug in it.