### PR TITLE
Revert ubi-minimal version

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
Problem:
Yum installation requires older packages that were upgraded in the new image version: ubi-minimal:8.1-409

Original PR: https://github.com/confluentinc/common-docker/pull/70
Ticket:  https://confluentinc.atlassian.net/browse/ST-3476

Solution:
Temporary revert to older images until issue is fixed by Redhat.
