### PR TITLE
ST-3550: Use latest vesion of ubi8-minimal image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
RedHat fixed the bug with the latest image that was causing us an issue so I am setting our base image back to using the latest available version.