### PR TITLE
Bump confluent-docker-utils to 0.0.38

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,2 +1,2 @@
 python-dateutil==2.8.0
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.37
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.38


### PR DESCRIPTION
# what
Bump confluent-docker-utils to 0.0.38 to install module `six`. Ksql-images(after 5.4.x) are currently failing on 
```
ImportError: No module named six
```

related pr: https://github.com/confluentinc/confluent-docker-utils/pull/22