### PR TITLE
pin zulu image version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM azul/zulu-openjdk-debian:8
+FROM azul/zulu-openjdk-debian:8u242
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
# what
In the new zulu open jdk image, they switch debian base version to debian 10 buster, which broken the python thing, I am not sure whether it can break more things. So I pin the version to be `8u242` which is release 3 months ago and still use debian 9 stretch.