### PR TITLE
Stop installing deprecated source lists

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -55,9 +55,6 @@ ENV ZULU_OPENJDK_VERSION="8=8.38.0.13"
 ENV LANG="C.UTF-8"
 
 RUN echo "===> Updating debian ....." \
-    # TODO debian jessie has been deprecated and is only ex
-    && echo "deb http://archive.debian.org/debian/ jessie main" > /etc/apt/sources.list \
-    && echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list \
     && apt-get -qq update \
     \
     && echo "===> Installing curl wget netcat python...." \


### PR DESCRIPTION
Akin to https://github.com/confluentinc/cp-docker-images/pull/853 but need to make the similar change here.