### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/base/include/etc/confluent/docker/bash-config
+++ b/base/include/etc/confluent/docker/bash-config
@@ -21,8 +21,3 @@ if [ "${TRACE:-}" == "true" ]; then
   set -o verbose \
       -o xtrace
 fi
-
-
-function show_env {
-    env | sort | grep -vP 'PASSWORD|JAAS_CONFIG'
-}


### PR DESCRIPTION
We don't want people printing out the environment variables in the logs during startup because they contain sensitive data.