### PR TITLE
ST-3733: Upgrading version of docker utils in debian images to 0.0.38

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -69,7 +69,7 @@ RUN echo "===> Updating debian ....." \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
     && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --only-binary --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --only-binary --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.38 \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \


### PR DESCRIPTION
We upgraded the version of docker utils python package in the debian 9 and ubi8 images, but not the debian 8 images. This is bring them to parity.