### PR TITLE
ST-3779: Enable build for jmxterm image

### DIFF
--- a/jmxterm/Dockerfile.deb8
+++ b/jmxterm/Dockerfile.deb8
@@ -27,4 +27,4 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
 WORKDIR /opt
 
-RUN wget http://downloads.sourceforge.net/project/cyclops-group/jmxterm/1.0-alpha-4/jmxterm-1.0-alpha-4-uber.jar -O /opt/jmxterm-1.0-alpha-4-uber.jar
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar

--- a/jmxterm/Dockerfile.deb9
+++ b/jmxterm/Dockerfile.deb9
@@ -1,0 +1,30 @@
+#
+# Copyright 2017 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_TAG}
+
+MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+WORKDIR /opt
+
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar

--- a/jmxterm/Dockerfile.ubi8
+++ b/jmxterm/Dockerfile.ubi8
@@ -1,0 +1,34 @@
+#
+# Copyright 2017 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_TAG}
+
+MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+
+USER root
+WORKDIR /opt
+
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar
+
+USER appuser
+WORKDIR /home/appuser

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,8 @@
         <module>utility-belt</module>
         <module>docker-utils</module>
         <module>base</module>
-        <!-- Disabling these modules since they are not used right now -->
-        <!--
         <module>jmxterm</module>
-        <module>kerberos</module>
-        -->
+        <!-- <module>kerberos</module> -->
     </modules>
 
     <properties>


### PR DESCRIPTION
I am enabling the build for the jmxterm image for deb8, deb9, and ubi8.