### PR TITLE
ST-3784: Upgraded the version of jmxterm to 1.0.1 in the jmxterm image

### DIFF
--- a/jmxterm/Dockerfile.deb8
+++ b/jmxterm/Dockerfile.deb8
@@ -27,4 +27,4 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
 WORKDIR /opt
 
-RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0.1-uber.jar" -o /opt/jmxterm-1.0.1-uber.jar

--- a/jmxterm/Dockerfile.deb9
+++ b/jmxterm/Dockerfile.deb9
@@ -27,4 +27,4 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
 WORKDIR /opt
 
-RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0.1-uber.jar" -o /opt/jmxterm-1.0.1-uber.jar

--- a/jmxterm/Dockerfile.ubi8
+++ b/jmxterm/Dockerfile.ubi8
@@ -28,7 +28,7 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 USER root
 WORKDIR /opt
 
-RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0-alpha-4-uber.jar" -o /opt/jmxterm-1.0-alpha-4-uber.jar
+RUN curl -s -L "https://s3-us-west-2.amazonaws.com/confluent-packaging-tools/jmxterm-1.0.1-uber.jar" -o /opt/jmxterm-1.0.1-uber.jar
 
 USER appuser
 WORKDIR /home/appuser


### PR DESCRIPTION
Upgrading the version of jmxterm in the jmxterm image to a stable newer release version (1.0.1) from an older version. Built and ran the Docker image using the newer version successfully to test it. Started jmxterm in the container and verified that it was using the newer version using the "about" command.