### PR TITLE
ST-3784: Fix jenkins file to tag and push cp-jmxterm images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ dockerfile {
     nodeLabel = 'docker-oraclejdk8-compose-swarm'
     dockerPush = true
     usePackages = true
-    dockerRepos = ['confluentinc/cp-base-new']
+    dockerRepos = ['confluentinc/cp-base-new', 'confluentinc/cp-jmxterm']
     slackChannel = '#tools-notifications'
     mvnSkipDeploy = true
     cron = ''


### PR DESCRIPTION
When I re-enabled the build for cp-jmxterm images I forgot to update the jenkins file which requires a list of the docker images being built. Since this image wasn't in the list it was building the images but not tagging them and uploading them to ECR. This will make sure they are tagged and uploaded.