### PR TITLE
Set default image type to ubi8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </modules>
 
     <properties>
-        <docker.os_type>deb8</docker.os_type>
+        <docker.os_type>ubi8</docker.os_type>
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
     </properties>


### PR DESCRIPTION
Since we no longer build debian images the default image os type should be ubi8. It looks like I missed this when removing the debian images.