### PR TITLE
ST-3962: update confluent-docker-utils to latest

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.25
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39


### PR DESCRIPTION
Creating a new pull request against `4.0.x` as suggested in #86. Simply changing the base didn't quite work.