### PR TITLE
ST-3962: update confluent-docker-utils to latest

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -41,7 +41,7 @@ COPY requirements.txt .
 
 RUN apt update \
     && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
-    && pip install --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && pip install --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.25
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39


### PR DESCRIPTION
`--install-option` causes `pip` to not use any wheel files, which causes issues for `pynacl` that will attempt compilation (and requires  `libssl-dev`). It is better to use `--prefix` option instead.