### PR TITLE
ST-3962: update confluent-docker-utils to latest

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -31,7 +31,6 @@ LABEL io.confluent.docker=true
 
 # Python
 ENV PYTHON_VERSION="2.7.9-1"
-ENV PYTHON_PIP_VERSION="8.1.2"
 
 # Confluent
 ENV SCALA_VERSION="2.12"
@@ -54,6 +53,8 @@ ENV ZULU_OPENJDK_VERSION="8=8.38.0.13"
 # base image that supports it
 ENV LANG="C.UTF-8"
 
+COPY requirements.txt .
+
 RUN echo "===> Updating debian ....." \
     && apt-get -qq update \
     \
@@ -68,8 +69,7 @@ RUN echo "===> Updating debian ....." \
                 python=${PYTHON_VERSION} \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
-    && pip install --no-cache-dir --upgrade pip==${PYTHON_PIP_VERSION} \
-    && pip install --only-binary --no-cache-dir git+https://github.com/confluentinc/confluent-docker-utils@v0.0.20 \
+    && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -41,7 +41,7 @@ COPY requirements.txt .
 
 RUN apt update \
     && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
-    && pip install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,2 +1,2 @@
 python-dateutil==2.8.0
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.38
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39


### PR DESCRIPTION
A few additional points
- hardcoded version in dockerfile is not a good idea
- pinned version of `pip` is way too old. I am not aware of a good reason to keep it that old.
- `--prefix` is better than `--install-option`. The latter forces non-use of wheel files.