### PR TITLE
Use a more up-to-date Azul repo

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -43,19 +43,20 @@ ENV LANG="C.UTF-8"
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
 # Zulu openJDK
-ENV ZULU_OPENJDK="zulu-11-11.35+15-1"
+ENV ZULU_OPENJDK="zulu-11-11.99+0-1"
 
 ENV PYTHON_VERSION="36-3.6.8"
 
 COPY requirements.txt .
 
 RUN microdnf install yum \
-    && yum update -q -y \
+    && yum update -y \
     && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
     && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
-    && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
-    && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
+    # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
+    && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
+    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
     && yum -y install ${ZULU_OPENJDK} \
     && yum remove -y git \
     && yum clean all \


### PR DESCRIPTION
It was discovered that `cp-server` and `cp-server-connect` images are all running different Java versions, to summarize this is the reason why:

* cp-base-new - installs an (outdated) azul yum repo - We are pinning that version to zulu-11-11.35+15-1 in the base - which equates to Java “11.0.5” https://github.com/confluentinc/common-docker/blob/6.0.x/base/Dockerfile.ubi8#L57-L58

* cp-server Inherits from cp-base-new, runs an unbounded yum update and updates to zulu-11-11.39+15-2 (which roughly equates to Java “11.0.7") , which also pulls in a zulu-repo that installs a different/seemly more-updated yum repo https://github.com/confluentinc/kafka-images/blob/6.0.x/server-connect-base/Dockerfile.ubi8#L50

* cp-server-connect-base inherits from cp-server, and now that cp-server installed a better-and-more-updated-zull repo & it runs an unbounded yum update, which then picks up zulu-11-11.99+0-1 which roughly equates to Java “11.0.8” https://github.com/confluentinc/kafka-images/blob/6.0.x/server/Dockerfile.ubi8#L55

This change aims to install the Azul repo from the correct place, and update to the latest avail (as of today) Zulu-11 JDK.