### PR TITLE
ST-4157: Use more up-to-date zulu repo

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -47,7 +47,7 @@ ENV CONFLUENT_VERSION=$CONFLUENT_VERSION
 ENV CONFLUENT_DEB_VERSION="1"
 
 # Zulu
-ENV ZULU_OPENJDK_VERSION="8=8.38.0.13"
+ENV ZULU_OPENJDK_VERSION="8=8.99.0.0-1"
 
 # This affects how strings in Java class files are interpreted.  We want UTF-8 and this is the only locale in the
 # base image that supports it
@@ -72,8 +72,11 @@ RUN echo "===> Updating debian ....." \
     && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
-    && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
-    && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
+    # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachAPTRepositoryUbuntuOrDebianSys.htm
+    && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0xB1998361219BD9C9 \
+    && curl -o /tmp/zulu-repo_1.0.0-2_all.deb https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-2_all.deb \
+    && dpkg --install /tmp/zulu-repo_1.0.0-2_all.deb \
+    && rm /tmp/zulu-repo_1.0.0-2_all.deb \
     && apt-get -qq update \
     && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
     && echo "===> Installing Kerberos Patch ..." \

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM azul/zulu-openjdk-debian:8u242
+FROM azul/zulu-openjdk-debian:8u262
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -43,19 +43,20 @@ ENV LANG="C.UTF-8"
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
 # Zulu openJDK
-ENV ZULU_OPENJDK="zulu-8-8.40.0.25"
+ENV ZULU_OPENJDK="zulu-8-8.99.0.0-1"
 
 ENV PYTHON_VERSION="36-3.6.8"
 
 COPY requirements.txt .
 
 RUN microdnf install yum \
-    && yum update -q -y \
+    && yum update -y \
     && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
     && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
-    && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
-    && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
+    # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
+    && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
+    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
     && yum -y install ${ZULU_OPENJDK} \
     && yum remove -y git \
     && yum clean all \


### PR DESCRIPTION
"backporting" https://github.com/confluentinc/common-docker/pull/100

* Use more up to date Zulu Repo
* Install latest zulu-8 JVM (as of today) (in both debs & ubi images)