### PR TITLE
Bump cp-base-new 53x to 8u262

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM azul/zulu-openjdk-debian:8u242
+FROM azul/zulu-openjdk-debian:8u262
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
Bumping this base image for ksql's-derrived image in 5.3.x world.