### PR TITLE
Add sanity test run to cub/dub & Fix python modules

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -69,7 +69,7 @@ RUN echo "===> Updating debian ....." \
                 python=${PYTHON_VERSION} \
     && echo "===> Installing python packages ..."  \
     && curl -fSL "https://bootstrap.pypa.io/get-pip.py" | python \
-    && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
+    && pip install --force-reinstall --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachAPTRepositoryUbuntuOrDebianSys.htm

--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -86,3 +86,7 @@ RUN echo "===> Updating debian ....." \
 ENV CUB_CLASSPATH=/etc/confluent/docker/docker-utils.jar
 COPY include/etc/confluent/docker /etc/confluent/docker
 COPY target/docker-utils-${CONFLUENT_VERSION}-jar-with-dependencies.jar /etc/confluent/docker/docker-utils.jar
+
+# This ensures these tools function
+RUN /usr/local/bin/dub --help
+RUN /usr/local/bin/cub --help

--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -86,7 +86,3 @@ RUN echo "===> Updating debian ....." \
 ENV CUB_CLASSPATH=/etc/confluent/docker/docker-utils.jar
 COPY include/etc/confluent/docker /etc/confluent/docker
 COPY target/docker-utils-${CONFLUENT_VERSION}-jar-with-dependencies.jar /etc/confluent/docker/docker-utils.jar
-
-# This ensures these tools function
-RUN /usr/local/bin/dub --help
-RUN /usr/local/bin/cub --help

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -52,3 +52,7 @@ ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 
 COPY include/etc/confluent/docker /etc/confluent/docker
+
+# This ensures these tools function
+RUN /usr/local/bin/dub --help
+RUN /usr/local/bin/cub --help

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -41,7 +41,7 @@ COPY requirements.txt .
 
 RUN apt update \
     && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
-    && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
+    && pip install --force-reinstall --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -41,7 +41,7 @@ COPY requirements.txt .
 
 RUN apt update \
     && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
-    && pip install --force-reinstall --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
+    && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \
@@ -52,7 +52,3 @@ ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 
 COPY include/etc/confluent/docker /etc/confluent/docker
-
-# This ensures these tools function
-RUN /usr/local/bin/dub --help
-RUN /usr/local/bin/cub --help

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -74,9 +74,5 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir /licenses
 COPY license.txt /licenses
 
-# This ensures these tools function
-RUN /usr/local/bin/dub --help
-RUN /usr/local/bin/cub --help
-
 USER appuser
 WORKDIR /home/appuser

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -74,5 +74,9 @@ COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 RUN mkdir /licenses
 COPY license.txt /licenses
 
+# This ensures these tools function
+RUN /usr/local/bin/dub --help
+RUN /usr/local/bin/cub --help
+
 USER appuser
 WORKDIR /home/appuser

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -53,7 +53,7 @@ RUN microdnf install yum \
     && yum update -y \
     && yum install -y git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
-    && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && pip3 install --force-reinstall --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
     # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
     && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil==2.8.0
-ipaddress=1.0.17
-backports.ssl-match-hostname=3.7.0.1
+ipaddress==1.0.17
+backports.ssl-match-hostname==3.7.0.1
 git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,2 +1,4 @@
 python-dateutil==2.8.0
+ipaddress=1.0.17
+backports.ssl-match-hostname=3.7.0.1
 git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,4 +1,2 @@
 python-dateutil==2.8.0
-ipaddress==1.0.17
-backports.ssl-match-hostname==3.7.0.1
 git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39

--- a/base/test/test_base_image.py
+++ b/base/test/test_base_image.py
@@ -19,8 +19,8 @@ class BaseImageTest(unittest.TestCase):
     def test_cub_dub_runable(self):
         dub_cmd = "bash -c '/usr/local/bin/dub --help'"
         cub_cmd = "bash -c '/usr/local/bin/cub --help'"
-        self.assertTrue(b"Docker Utility Belt" in utils.run_docker_command(image=self.image, dub_cmd))
-        self.assertTrue(b"Confluent Platform Utility Belt." in utils.run_docker_command(image=self.image, cub_cmd))
+        self.assertTrue(b"Docker Utility Belt" in utils.run_docker_command(image=self.image, command=dub_cmd))
+        self.assertTrue(b"Confluent Platform Utility Belt." in utils.run_docker_command(image=self.image, command=cub_cmd))
 
 
 if __name__ == '__main__':

--- a/base/test/test_base_image.py
+++ b/base/test/test_base_image.py
@@ -16,6 +16,12 @@ class BaseImageTest(unittest.TestCase):
         self.assertTrue(utils.path_exists_in_image(self.image, "/usr/local/bin/dub"))
         self.assertTrue(utils.path_exists_in_image(self.image, "/usr/local/bin/cub"))
 
+    def test_cub_dub_runable(self):
+        dub_cmd = "bash -c '/usr/local/bin/dub --help'"
+        cub_cmd = "bash -c '/usr/local/bin/cub --help'"
+        self.assertTrue(b"Docker Utility Belt" in utils.run_docker_command(image=self.image, dub_cmd))
+        self.assertTrue(b"Confluent Platform Utility Belt." in utils.run_docker_command(image=self.image, cub_cmd))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Recent updates to the dub9 base image (https://github.com/confluentinc/common-docker/pull/101) is causing issues with the cub/dub tool:

```
root@f1740a6b656f:/# /usr/local/bin/dub --help
Traceback (most recent call last):
  File "/usr/local/bin/dub", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'ipaddress>=1.0.16; python_version < "3.3"' distribution was not found and is required by docker
root@f1740a6b656f:/# cub
Traceback (most recent call last):
  File "/usr/local/bin/cub", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3191, in <module>
    @_call_aside
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3175, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3204, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'ipaddress>=1.0.16; python_version < "3.3"' distribution was not found and is required by docker
```

Something happened to the python modules when we switched to an updated base. `ipaddress` did come from the debain package manager, so its was "satisfied" for `confluent-docker-utils`'s requirements, but is later removed by the packaging manager, thus leaving `confluent-docker-utils`'s dependencies (and more) no longer satisfied, hence this error.

First and fore-most, I added a test to catch this condition in the build - That failed here:

https://jenkins.confluent.io/job/confluentinc-pr/job/common-docker/job/PR-103/5/

I then added `--force-reinstall` to all pip commands to force install the `confluent-docker-utils`'s requirements to the /usr/local prefix, even if its already "satisfied" from the OS distribution. Now the OS packages can be safely removed.