### PR TITLE
Undo update to azul/zulu-openjdk-debian:8u262 & add test

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM azul/zulu-openjdk-debian:8u262
+FROM azul/zulu-openjdk-debian:8u242
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID

--- a/base/test/test_base_image.py
+++ b/base/test/test_base_image.py
@@ -22,6 +22,12 @@ class BaseImageTest(unittest.TestCase):
         self.assertTrue(utils.path_exists_in_image(self.image, "/usr/local/bin/dub"))
         self.assertTrue(utils.path_exists_in_image(self.image, "/usr/local/bin/cub"))
 
+    def test_cub_dub_runable(self):
+        dub_cmd = "bash -c '/usr/local/bin/dub --help'"
+        cub_cmd = "bash -c '/usr/local/bin/cub --help'"
+        self.assertTrue(b"Docker Utility Belt" in utils.run_docker_command(image=self.image, command=dub_cmd))
+        self.assertTrue(b"Confluent Platform Utility Belt." in utils.run_docker_command(image=self.image, command=cub_cmd))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The update here https://github.com/confluentinc/common-docker/pull/101 changed the Debian base image from deb9 to deb10, thats a nono in our book.

I'm also adding a test from https://github.com/confluentinc/common-docker/pull/103 to pick up regressions.