### PR TITLE
ST-3461: Implement nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,4 +10,5 @@ dockerfile {
     cron = ''
     cpImages = true
     osTypes = ['ubi8']
+    nanoVersion = true
 }

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <packaging>pom</packaging>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>utility-belt</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.common-docker.version}</version>
         </dependency>
 
         <dependency>

--- a/docker-utils/pom.xml
+++ b/docker-utils/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <organization>
@@ -39,7 +39,7 @@
     <artifactId>docker-utils</artifactId>
     <packaging>jar</packaging>
     <name>docker-utils</name>
-    <version>${confluent.version}</version>
+    <version>6.1.0-0</version>
 
     <licenses>
         <license>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>utility-belt</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.common-docker.version}</version>
         </dependency>
 
         <dependency>

--- a/jmxterm/pom.xml
+++ b/jmxterm/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/kerberos/pom.xml
+++ b/kerberos/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <groupId>io.confluent</groupId>
     <artifactId>common-docker</artifactId>
     <packaging>pom</packaging>
+    <version>6.1.0-0</version>
 
     <name>${project.artifactId}</name>
     <description>Common Docker utilities, and new cp-base image</description>
@@ -28,6 +29,7 @@
     <properties>
         <docker.os_type>ubi8</docker.os_type>
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
-        <docker.tag>${project.version}-${docker.os_type}</docker.tag>
+        <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
+        <io.confluent.common-docker.version>6.1.0-0</io.confluent.common-docker.version>
     </properties>
 </project>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>utility-belt</artifactId>
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>common-utils</artifactId>
-            <version>${project.version}</version>
+            <version>${io.confluent.common.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions.

These changes will be merged during phase two of the nano versioning roll out.