### PR TITLE
Pin setuptools<50.0.0

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,2 +1,3 @@
 python-dateutil==2.8.0
+setuptools<50.0.0
 git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39


### PR DESCRIPTION
The 5.4.x -> master jobs are failing to build UBI8 Images because the location of the dub/cub python scripts moved from (expected) `/usr/local/bin` to (now) `/usr/bin`.

It seems there was a setuptools release over the weekend:

```
-  Downloading https://files.pythonhosted.org/packages/c3/a9/5dc32465951cf4812e9e93b4ad2d314893c2fa6d5f66ce5c057af6e76d85/setuptools-49.6.0-py3-none-any.whl (803kB)
+  Downloading https://files.pythonhosted.org/packages/b0/8b/379494d7dbd3854aa7b85b216cb0af54edcb7fce7d086ba3e35522a713cf/setuptools-50.0.0-py3-none-any.whl (783kB)
```

This release has seemed to have caused a lot of issues in the community: https://github.com/pypa/setuptools/issues/2352

Their solution is to pin bellow 50.0.0 until its fixed, which is what we're doing here.