### PR TITLE
Bump confluent-docker-utils to v0.0.40

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.39
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40


### PR DESCRIPTION
Followup to https://github.com/confluentinc/confluent-docker-utils/pull/24