### PR TITLE
Specify org.junit.jupiter:junit-jupiter-api:5.7.0 as test dependency

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -193,6 +193,14 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
We're getting a build issue here:

```
16:27:38  [INFO] Running io.confluent.admin.utils.ClusterWaitTest
[2020-09-24T23:28:10.187Z] [ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 26.754 s <<< FAILURE! - in io.confluent.admin.utils.ClusterWaitTest
[2020-09-24T23:28:10.187Z] [ERROR] io.confluent.admin.utils.ClusterWaitTest.isKafkaReadyWait  Time elapsed: 0 s  <<< ERROR!
16:28:10  java.lang.NoClassDefFoundError: org/junit/jupiter/api/Assertions
16:28:10  	at io.confluent.admin.utils.ClusterWaitTest.isKafkaReadyWait(ClusterWaitTest.java:85)
16:28:10  Caused by: java.lang.ClassNotFoundException: org.junit.jupiter.api.Assertions
16:28:10  	at io.confluent.admin.utils.ClusterWaitTest.isKafkaReadyWait(ClusterWaitTest.java:85)
```

@ewencp believes it may be due to this change: https://github.com/apache/kafka/pull/9282