### PR TITLE
MINOR: Use junit.jupiter.version property

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -197,7 +197,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Follow-up to https://github.com/confluentinc/common-docker/pull/111 but this time, using the property I defined in the common project: https://github.com/confluentinc/common/pull/299