### PR TITLE
Use 0.0.42 release of confluent-docker-utils

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@ST-4684
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.42

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,3 +1,1 @@
-python-dateutil==2.8.0
-setuptools<50.0.0
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40
+git+https://github.com/confluentinc/confluent-docker-utils@ST-4684


### PR DESCRIPTION
Helper PR to test https://github.com/confluentinc/confluent-docker-utils/pull/28

~~Provided that this builds & tests fine, then I will merge the above PR, and then change `ST-4684` to the tagged release.~~ Merged, so now this PR is for pinning that tag-ed version of `v0.0.42`

The removals of:

```
python-dateutil==2.8.0
setuptools<50.0.0
```

Were there for python27-compat reasons, in 6.0.x going forward, we only care about python3, and therefore justified IMO. I have branched `python27-compat` from `v0.40.0` where we'll maintain python27-compatible dependency sets for the older docker images (5.0.x -> 5.5.x)