### PR TITLE
Upgrade Pip & Setuptools to install newer cryptography library

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -53,7 +53,8 @@ RUN microdnf install yum \
     && yum update -y \
     && yum install -y openssl git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
-    && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
+    && python3 -m pip install --upgrade pip setuptools \
+    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade -rrequirements.txt \
     # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
     && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \


### PR DESCRIPTION
- cryptography requires newer setuptools/pip in order to build
- Invoke pip through 'python3 -m pip ...' as per https://github.com/pypa/pip/issues/5599

Our builds are failing at:

```
10:29:00  [INFO] Collecting cryptography>=2.6.1 (from confluent-docker-utils==0.0.42->-r requirements.txt (line 1))
10:29:01  [INFO]   Downloading https://files.pythonhosted.org/packages/35/52/a3b9c3d8ce84544bfe8d663ba993e0593d9c518d6c08f01f6f8fff87b895/cryptography-3.4.2.tar.gz (544kB)
10:29:01  [INFO]     Complete output from command python setup.py egg_info:
10:29:01  [INFO]     
10:29:01  [INFO]             =============================DEBUG ASSISTANCE==========================
10:29:01  [INFO]             If you are seeing an error here please try the following to
10:29:01  [INFO]             successfully install cryptography:
10:29:01  [INFO]     
10:29:01  [INFO]             Upgrade to the latest pip and try again. This will fix errors for most
10:29:01  [INFO]             users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
10:29:01  [INFO]             =============================DEBUG ASSISTANCE==========================
10:29:01  [INFO]     
10:29:01  [INFO]     Traceback (most recent call last):
10:29:01  [INFO]       File "<string>", line 1, in <module>
10:29:01  [INFO]       File "/tmp/pip-build-sb_kwnob/cryptography/setup.py", line 14, in <module>
10:29:01  [INFO]         from setuptools_rust import RustExtension
10:29:01  [INFO]     ModuleNotFoundError: No module named 'setuptools_rust'
10:29:01  [INFO]     
10:29:01  [INFO]     ----------------------------------------
10:29:01  [INFO] Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-sb_kwnob/cryptography/
```

So we upgrade pip, then install modules from requirements.txt.