### PR TITLE
Upgrade Pip & Setuptools to install newer cryptography library (#119)

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -55,9 +55,8 @@ RUN microdnf install yum \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade pip setuptools \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@v0.0.42' \
-    # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
-    && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
-    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
+    && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
+    && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
     && yum -y install ${ZULU_OPENJDK} \
     && yum remove -y git \
     && yum clean all \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -53,9 +53,11 @@ RUN microdnf install yum \
     && yum update -y \
     && yum install -y openssl git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
     && alternatives --set python /usr/bin/python3 \
-    && pip3 install --only-binary --install-option="--prefix=/usr/local" --upgrade -rrequirements.txt \
-    && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
-    && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
+    && python3 -m pip install --upgrade pip setuptools \
+    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@v0.0.42' \
+    # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachYumRepositoryRHEL-SLES-OracleLinuxSys.htm
+    && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
+    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
     && yum -y install ${ZULU_OPENJDK} \
     && yum remove -y git \
     && yum clean all \


### PR DESCRIPTION
- Use docker-utils v0.0.42 for Py3.x compat modules
- cryptography requires newer setuptools/pip in order to build
- Invoke pip through 'python3 -m pip ...' as per https://github.com/pypa/pip/issues/5599

Backport of https://github.com/confluentinc/common-docker/commit/bf6da34a521f720ae22d166f8aae4c7c61becb7b of sorts. We are also having the UBI image use a newer version of docker-utils to obtain updated python modules that fix CVEs:

* https://confluentinc.atlassian.net/browse/ST-4977
* https://confluentinc.atlassian.net/browse/ST-4979
* https://confluentinc.atlassian.net/browse/ST-4978

PR build shows:

```
[2021-02-09T19:40:03.753Z] [INFO] Successfully installed Jinja2-2.11.2 MarkupSafe-1.1.1 PyYAML-5.4.1 attrs-20.3.0 bcrypt-3.2.0 boto3-1.9.128 botocore-1.12.253 cached-property-1.5.2 certifi-2020.12.5 cffi-1.14.4 chardet-3.0.4 confluent-docker-utils-0.0.42 cryptography-3.4.3 docker-3.7.2 docker-compose-1.25.2 docker-pycreds-0.4.0 dockerpty-0.4.1 docopt-0.6.2 docutils-0.15.2 idna-2.10 importlib-metadata-3.4.0 jmespath-0.10.0 jsonschema-3.2.0 mock-2.0.0 paramiko-2.4.2 pbr-5.5.1 pyasn1-0.4.8 pycparser-2.20 pynacl-1.4.0 pyrsistent-0.17.3 python-dateutil-2.8.1 requests-2.25.0 s3transfer-0.2.1 six-1.14.0 texttable-1.6.3 typing-extensions-3.7.4.3 urllib3-1.25.11 websocket-client-0.57.0 zipp-3.4.0
```

* PyYAML-5.4.1
* urllib3-1.25.11
* cryptography-3.4.3

Which hits all of those ST ticket's requests.

> What about the debain images.

We're in discussions with Infosec (Mathew's team) on this, and this morning our meeting we agreed that addressing the vulnerabilities in UBI and having that to be customer's resolution path is acceptable.

> What about debian images 4.1.x -> 5.3.x?

We're still in discussion, for now this PR addresses the issues in 5.4.x and 5.5.x in a reasonable manner.