### PR TITLE
Build: Move zookeeper to direct compile scope

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -100,6 +100,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <type>test-jar</test>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -103,7 +103,7 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
-            <type>test-jar</test>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -97,8 +97,6 @@
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Builds here are failing after https://github.com/apache/kafka/commit/7a3ebbebbc6aed2049f22c650a52f6f685546207 was merged in, which killed this projects transitive dependency on zookeeper, so we declare it directly now.