### PR TITLE
Fix: only last topic spec mismatch failure in cub script

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -75,6 +75,7 @@ public class TopicEnsureCommand {
 
     ArgumentParser parser = createArgsParser();
     boolean success = false;
+    boolean validationSuccess = false;
     try {
       Namespace res = parser.parseArgs(args);
       log.debug("Arguments {}. ", res);
@@ -90,6 +91,7 @@ public class TopicEnsureCommand {
         System.err.printf("Topic [ %s ] exists ? %s\n", spec.name(), success);
         if (success) {
           success = topicEnsure.validateTopic(spec, res.getInt("timeout"));
+          if(!success) validationSuccess = false;
           System.err.printf("Topic spec [ %s ] valid ? %s\n", spec, success);
         } else if (res.getBoolean("create_if_not_exists")) {
           success = topicEnsure.createTopic(spec, res.getInt("timeout"));
@@ -99,17 +101,17 @@ public class TopicEnsureCommand {
     } catch (ArgumentParserException e) {
       if (args.length == 0) {
         parser.printHelp();
-        success = true;
+        validationSuccess = true;
       } else {
         parser.handleError(e);
-        success = false;
+        validationSuccess = false;
       }
     } catch (Exception e) {
       log.error("Error while running topic-ensure {}.", e);
-      success = false;
+      validationSuccess = false;
     }
 
-    if (success) {
+    if (validationSuccess) {
       System.exit(0);
     } else {
       System.exit(1);

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -91,7 +91,7 @@ public class TopicEnsureCommand {
         System.err.printf("Topic [ %s ] exists ? %s\n", spec.name(), success);
         if (success) {
           success = topicEnsure.validateTopic(spec, res.getInt("timeout"));
-          if(!success) {
+          if (!success) {
             validationSuccess = false;
           }
           System.err.printf("Topic spec [ %s ] valid ? %s\n", spec, success);

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -75,7 +75,6 @@ public class TopicEnsureCommand {
 
     ArgumentParser parser = createArgsParser();
     boolean success = false;
-    boolean validationSuccess = false;
     try {
       Namespace res = parser.parseArgs(args);
       log.debug("Arguments {}. ", res);
@@ -91,10 +90,10 @@ public class TopicEnsureCommand {
         System.err.printf("Topic [ %s ] exists ? %s\n", spec.name(), success);
         if (success) {
           success = topicEnsure.validateTopic(spec, res.getInt("timeout"));
-          if (!success) {
-            validationSuccess = false;
-          }
           System.err.printf("Topic spec [ %s ] valid ? %s\n", spec, success);
+          if (!success) {
+            break;
+          }
         } else if (res.getBoolean("create_if_not_exists")) {
           success = topicEnsure.createTopic(spec, res.getInt("timeout"));
           System.err.printf("Topic [ %s ] created with spec: [ %s ] \n", spec.name(), spec);
@@ -103,17 +102,16 @@ public class TopicEnsureCommand {
     } catch (ArgumentParserException e) {
       if (args.length == 0) {
         parser.printHelp();
-        validationSuccess = true;
+        success = true;
       } else {
         parser.handleError(e);
-        validationSuccess = false;
       }
     } catch (Exception e) {
       log.error("Error while running topic-ensure {}.", e);
-      validationSuccess = false;
+      success = false;
     }
 
-    if (validationSuccess) {
+    if (success) {
       System.exit(0);
     } else {
       System.exit(1);

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -91,7 +91,9 @@ public class TopicEnsureCommand {
         System.err.printf("Topic [ %s ] exists ? %s\n", spec.name(), success);
         if (success) {
           success = topicEnsure.validateTopic(spec, res.getInt("timeout"));
-          if(!success) validationSuccess = false;
+          if(!success) {
+            validationSuccess = false;
+          }
           System.err.printf("Topic spec [ %s ] valid ? %s\n", spec, success);
         } else if (res.getBoolean("create_if_not_exists")) {
           success = topicEnsure.createTopic(spec, res.getInt("timeout"));


### PR DESCRIPTION
## What
- This Fix only last topic spec mismatch failure in cub script, this will return an error if any topic does not match from actual topic spec
## Why
- There is a bug in the cub script that returns only the error status of the last checked topic.

## JIRA
[LOGGING-308](https://confluentinc.atlassian.net/browse/LOGGING-308)

## References 
- https://github.com/confluentinc/confluent-docker-utils/blob/master/confluent/docker_utils/cub.py#L348