### PR TITLE
fix: Use BrokerSecurityConfigs after SaslConfigs deprecation

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
@@ -16,6 +16,7 @@
 package io.confluent.admin.utils;
 
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.slf4j.Logger;
@@ -135,7 +136,7 @@ public class EmbeddedKafkaCluster {
 
       saslProperties = new Properties();
       saslProperties.put(SaslConfigs.SASL_MECHANISM, "GSSAPI");
-      saslProperties.put(SaslConfigs.SASL_ENABLED_MECHANISMS, "GSSAPI");
+      saslProperties.put(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, "GSSAPI");
 
       this.brokerTrustStoreFile = Option.apply(trustStoreFile);
       this.brokerSaslProperties = Option.apply(saslProperties);


### PR DESCRIPTION
Upstream change that triggered this: https://github.com/confluentinc/kafka/commit/e8754ba7a01f33ba503ef79de66a5f644cc2ced8

```
[2021-04-06T16:36:06.950Z] [ERROR] COMPILATION ERROR : 
09:36:06  [INFO] -------------------------------------------------------------
[2021-04-06T16:36:06.951Z] [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java:[138,37] cannot find symbol
09:36:06    symbol:   variable SASL_ENABLED_MECHANISMS
09:36:06    location: class org.apache.kafka.common.config.SaslConfigs
```