### PR TITLE
build: Pin UBI package versions. Add security check update

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -98,11 +98,12 @@ RUN microdnf install yum \
     && chown appuser:appuser -R /etc/confluent/ /usr/logs
 
 # This is a step that will cause the build to fail of the package manager detects a security update is availible and isn't installed.
-# The ARG DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE is an "escape" hatch if you want to by-pass this check and build the container anyways, which
-# is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the ||) this check
-# will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a security update is availible.
-ARG DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE="false"
-RUN yum check-update --security || "${DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE}"
+# The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
+# is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the left
+# hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
+# security update is availible.
+ARG SKIP_SECURITY_UPDATE_CHECK="false"
+RUN yum check-update --security || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -59,11 +59,11 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 RUN microdnf install yum \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
     && curl -fSL -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
-    && yum install -y \
+    && yum install -y --setopt=install_weak_deps=False \
         git \
         "openssl${OPENSSL_VERSION}" \
         "wget${WGET_VERSION}" \
-        "nc${NETCAT_VERSION}" \
+        "nmap-ncat${NETCAT_VERSION}" \
         "python36${PYTHON36_VERSION}" \
         "tar${TAR_VERSION}" \
         "procps-ng${PROCPS_VERSION}" \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-ARG UBI_MINIMAL_VERSION
+ARG UBI_MINIMAL_VERSION="latest"
 FROM registry.access.redhat.com/ubi8/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 ARG PROJECT_VERSION
@@ -45,7 +45,7 @@ ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 ARG OPENSSL_VERSION=""
 ARG WGET_VERSION=""
 ARG NETCAT_VERSION=""
-ARH PYTHON36_VERSION=""
+ARG PYTHON36_VERSION=""
 ARG TAR_VERSION=""
 ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
@@ -70,7 +70,7 @@ RUN microdnf install yum \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
         "iputils${IPUTILS_VERSION}" \
         "hostname${HOSTNAME_VERSION}" \
-        "zulu-8${ZULU_OPENJDK_VERSION}"
+        "zulu-8${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}' \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -12,8 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ARG UBI_MINIMAL_VERSION
+FROM registry.access.redhat.com/ubi8/ubi-minimal:${UBI_MINIMAL_VERSION}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
@@ -42,29 +42,51 @@ ENV LANG="C.UTF-8"
 # Set the classpath for JARs required by `cub`
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
-# Zulu openJDK
-ENV ZULU_OPENJDK="zulu-8-8.40.0.25"
-
-ENV PYTHON_VERSION="36-3.6.8"
-
-COPY requirements.txt .
+ARG OPENSSL_VERSION=""
+ARG WGET_VERSION=""
+ARG NETCAT_VERSION=""
+ARH PYTHON36_VERSION=""
+ARG TAR_VERSION=""
+ARG PROCPS_VERSION=""
+ARG KRB5_WORKSTATION_VERSION=""
+ARG IPUTILS_VERSION=""
+ARG HOSTNAME_VERSION=""
+ARG ZULU_OPENJDK_VERSION=""
+ARG PYTHON_PIP_VERSION=""
+ARG PYTHON_SETUPTOOLS_VERSION=""
+ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 
 RUN microdnf install yum \
-    && yum update -y \
-    && yum install -y openssl git wget nc python${PYTHON_VERSION} tar procps krb5-workstation iputils hostname \
-    && alternatives --set python /usr/bin/python3 \
-    && python3 -m pip install --upgrade pip setuptools \
-    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@v0.0.43' \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
     && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
-    && yum -y install ${ZULU_OPENJDK} \
+    && yum install -y \
+        git \
+        "openssl${OPENSSL_VERSION}" \
+        "wget${WGET_VERSION}" \
+        "nc${NETCAT_VERSION}" \
+        "python36${PYTHON36_VERSION}" \
+        "tar${TAR_VERSION}" \
+        "procps-ng${PROCPS_VERSION}" \
+        "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
+        "iputils${IPUTILS_VERSION}" \
+        "hostname${HOSTNAME_VERSION}" \
+        "zulu-8${ZULU_OPENJDK_VERSION}"
+    && alternatives --set python /usr/bin/python3 \
+    && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
+    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}' \
     && yum remove -y git \
     && yum clean all \
     && rm -rf /tmp/* \
-    && rm -f requirements.txt \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && chown appuser:appuser -R /etc/confluent/ /usr/logs
+
+# This is a step that will cause the build to fail of the package manager detects a security update is availible and isn't installed.
+# The ARG DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE is an "escape" hatch if you want to by-pass this check and build the container anyways, which
+# is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the ||) this check
+# will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a security update is availible.
+ARG DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE="false"
+RUN yum check-update --security || "${DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE}"
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -42,6 +42,13 @@ ENV LANG="C.UTF-8"
 # Set the classpath for JARs required by `cub`
 ENV CUB_CLASSPATH='"/usr/share/java/cp-base-new/*"'
 
+# These ARGs are left blank indicating to the Dnf package manager to install the latest package
+# version that happens to be availible at this time. For reproducible builds, versions should be specified
+# as '-1.2.3-4.el8' on the command line. Or more preferibly the 'dockerfile-maven-plugin' is used
+# where these arguments are set in base/pom.xml under the <buildArgs> elements based on the commit you're
+# building from.
+
+# Redhat Package Versions
 ARG OPENSSL_VERSION=""
 ARG WGET_VERSION=""
 ARG NETCAT_VERSION=""
@@ -51,10 +58,19 @@ ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
 ARG IPUTILS_VERSION=""
 ARG HOSTNAME_VERSION=""
+
+# Zulu OpenJDK version
 ARG ZULU_OPENJDK_VERSION=""
+
+# Python Module Versions
 ARG PYTHON_PIP_VERSION=""
 ARG PYTHON_SETUPTOOLS_VERSION=""
+
+# Confluent Docker Utils Version (Namely the tag or branch to grab from git to install)
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
+
+# This can be overriden for an offline/air-gapped builds
+ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
 
 RUN microdnf install yum \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
@@ -73,7 +89,7 @@ RUN microdnf install yum \
         "zulu-8${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
-    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}" \
+    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -58,7 +58,7 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 
 RUN microdnf install yum \
     && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
-    && curl -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
+    && curl -fSL -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
     && yum install -y \
         git \
         "openssl${OPENSSL_VERSION}" \
@@ -73,7 +73,7 @@ RUN microdnf install yum \
         "zulu-8${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
-    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}' \
+    && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}" \
     && yum remove -y git \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/base/README.md
+++ b/base/README.md
@@ -18,7 +18,12 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *docker.test-registry*: (Optional) Registry to pull test dependency images from. Trailing `/` is required. Used as `DOCKER_TEST_REGISTRY` during testing. Defaults to the value of `docker.upstream-registry`.
 - *docker.test-tag*: (Optional) Use the given tag when pulling test dependency images. Used as `DOCKER_TEST_TAG` during testing. Defaults to the value of `docker.upstream-tag`.
 - *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `deb8`, `deb9`, and `ubi8`. Default value is `deb8`.
+- *docker.dont.fail.if.security.update.availible*: (Optional) The Dockerfile.ubi8 will run a security update check. If left to the default (false) and there is a pending security update that is not installed, then the build will fail, enforcing good security practices. If set to true, the check will pass no matter what NOT ADVISABLE. Default value is `false`.
+
+## Build arguments
+
 - *CONFLUENT_VERSION*: (Required) Specify the full Confluent Platform release version. Example: 5.4.0
+- See Dockferfile for more.
 
 
 ## Building

--- a/base/README.md
+++ b/base/README.md
@@ -18,7 +18,7 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *docker.test-registry*: (Optional) Registry to pull test dependency images from. Trailing `/` is required. Used as `DOCKER_TEST_REGISTRY` during testing. Defaults to the value of `docker.upstream-registry`.
 - *docker.test-tag*: (Optional) Use the given tag when pulling test dependency images. Used as `DOCKER_TEST_TAG` during testing. Defaults to the value of `docker.upstream-tag`.
 - *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `deb8`, `deb9`, and `ubi8`. Default value is `deb8`.
-- *docker.dont.fail.if.security.update.availible*: (Optional) The Dockerfile.ubi8 will run a security update check. If left to the default (false) and there is a pending security update that is not installed, then the build will fail, enforcing good security practices. If set to true, the check will pass no matter what NOT ADVISABLE. Default value is `false`.
+- *docker.skip-security-update-check*: (Optional) The Dockerfile.ubi8 will run a security update check. If left to the default (false) and there is a pending security update that is not installed, then the build will fail, enforcing good security practices. If set to true, the check will pass no matter what. NOT ADVISABLE USE AT YOUR OWN RISK. Default value is `false`.
 
 ## Build arguments
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -98,7 +98,7 @@
                         <!-- Redhat Package Versions -->
                         <OPENSSL_VERSION>-1.1.1g-15.el8_3</OPENSSL_VERSION>
                         <WGET_VERSION>-1.19.5-10.el8</WGET_VERSION>
-                        <NETCAT_VERSION>-3.20-6.el8</NETCAT_VERSION>
+                        <NETCAT_VERSION>-2:7.70-5.el8</NETCAT_VERSION>
                         <PYTHON36_VERSION>-3.6.8-2.module+el8.1.0+3334+5cb623d7</PYTHON36_VERSION>
                         <TAR_VERSION>-1.30-5.el8</TAR_VERSION>
                         <PROCPS_VERSION>-3.3.15-3.el8</PROCPS_VERSION>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -88,6 +88,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <!-- Redhat UBI Minimal Version -->
+                        <UBI_MINIMAL_VERSION>8.3-298</UBI_MINIMAL_VERSION>
+                        <!-- Redhat Package Versions -->
+                        <OPENSSL_VERSION>-1.1.1g-15.el8_3</OPENSSL_VERSION>
+                        <WGET_VERSION>-1.19.5-10.el8</WGET_VERSION>
+                        <NETCAT_VERSION>-3.20-6.el8</NETCAT_VERSION>
+                        <PYTHON36_VERSION>-3.6.8-2.module+el8.1.0+3334+5cb623d7</PYTHON36_VERSION>
+                        <TAR_VERSION>-1.30-5.el8</TAR_VERSION>
+                        <PROCPS_VERSION>-3.3.15-3.el8</PROCPS_VERSION>
+                        <KRB5_WORKSTATION_VERSION>-1.18.2-5.el8</KRB5_WORKSTATION_VERSION>
+                        <IPUTILS_VERSION>-20180629-2.el8</IPUTILS_VERSION>
+                        <HOSTNAME_VERSION>-3.20-6.el8</HOSTNAME_VERSION>
+                        <!-- ZULU OpenJDK Package Version -->
+                        <ZULU_OPENJDK_VERSION>-8.40.0.25</ZULU_OPENJDK_VERSION>
+                        <!-- Python Module Versions -->
+                        <PYTHON_PIP_VERSION>==21.*</PYTHON_PIP_VERSION>
+                        <PYTHON_SETUPTOOLS_VERSION>==54.*</PYTHON_SETUPTOOLS_VERSION>
+                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>v0.0.43</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
+                        <!-- Escape hatch option to bypass a security check. See the parent pom.xml for more details -->
+                        <DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>${docker.dont.fail.if.security.update.availible}</DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>
+                    </buildArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -93,25 +93,20 @@
                 <artifactId>dockerfile-maven-plugin</artifactId>
                 <configuration>
                     <buildArgs>
-                        <!-- Redhat UBI Minimal Version -->
-                        <UBI_MINIMAL_VERSION>8.3-298</UBI_MINIMAL_VERSION>
-                        <!-- Redhat Package Versions -->
-                        <OPENSSL_VERSION>-1.1.1g-15.el8_3</OPENSSL_VERSION>
-                        <WGET_VERSION>-1.19.5-10.el8</WGET_VERSION>
-                        <NETCAT_VERSION>-2:7.70-5.el8</NETCAT_VERSION>
-                        <PYTHON36_VERSION>-3.6.8-2.module+el8.1.0+3334+5cb623d7</PYTHON36_VERSION>
-                        <TAR_VERSION>-1.30-5.el8</TAR_VERSION>
-                        <PROCPS_VERSION>-3.3.15-3.el8</PROCPS_VERSION>
-                        <KRB5_WORKSTATION_VERSION>-1.18.2-5.el8</KRB5_WORKSTATION_VERSION>
-                        <IPUTILS_VERSION>-20180629-2.el8</IPUTILS_VERSION>
-                        <HOSTNAME_VERSION>-3.20-6.el8</HOSTNAME_VERSION>
-                        <!-- ZULU OpenJDK Package Version -->
-                        <ZULU_OPENJDK_VERSION>-8.40.0.25</ZULU_OPENJDK_VERSION>
-                        <!-- Python Module Versions -->
-                        <PYTHON_PIP_VERSION>==21.*</PYTHON_PIP_VERSION>
-                        <PYTHON_SETUPTOOLS_VERSION>==54.*</PYTHON_SETUPTOOLS_VERSION>
-                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>v0.0.43</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
-                        <!-- Escape hatch option to bypass a security check. See the parent pom.xml for more details -->
+                        <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                        <OPENSSL_VERSION>-${ubi.openssl.version}</OPENSSL_VERSION>
+                        <WGET_VERSION>-${ubi.wget.version}</WGET_VERSION>
+                        <NETCAT_VERSION>-${ubi.netcat.version}</NETCAT_VERSION>
+                        <PYTHON36_VERSION>-${ubi.python36.version}</PYTHON36_VERSION>
+                        <TAR_VERSION>-${ubi.tar.version}</TAR_VERSION>
+                        <PROCPS_VERSION>-${ubi.procps.version}</PROCPS_VERSION>
+                        <KRB5_WORKSTATION_VERSION>-${ubi.krb5.workstation.version}</KRB5_WORKSTATION_VERSION>
+                        <IPUTILS_VERSION>-${ubi.iputils.version}</IPUTILS_VERSION>
+                        <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
+                        <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
+                        <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
+                        <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
+                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${ubi.python.confluent.docker.utils.version}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                         <DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>${docker.dont.fail.if.security.update.availible}</DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>
                     </buildArgs>
                 </configuration>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -107,7 +107,7 @@
                         <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
                         <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${ubi.python.confluent.docker.utils.version}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
-                        <DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>${docker.dont.fail.if.security.update.availible}</DONT_FAIL_IF_SECURITY_UPDATE_AVAILIBLE>
+                        <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
                     </buildArgs>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -48,11 +48,10 @@
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>
         <ubi.python.confluent.docker.utils.version>v0.0.43</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
-        detects that there is security update avaibilbe to be installed. This is an inverted name since we're being clever
-        with bash's || {true,false} check to fail the build. If this is false: This will fail a build if a security update
-        is detected. If true, then the check will not impact the build. The default beahvior is to fail (false) the build
-        if an update is detected. Users may pass -Ddocker.dont.fail.if.security.update.availible=true on the maven CLI
-        to bypass this check and make the build complete, despit that being a bad idea. Use at your own risk!-->
-        <docker.dont.fail.if.security.update.availible>false</docker.dont.fail.if.security.update.availible>
+        detects that there is security update availible to be installed. Set to true if you want to skip the check
+        (more accurately the check is still done, it just won't fail if an update is detected), or leave it as
+        false to enforce the check. Users may override this behavior on the maven CLI by adding this option:
+        `-Ddocker.skip-security-update-check=true` -->
+        <docker.skip-security-update-check>false</docker.skip-security-update-check>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,24 @@
         <docker.os_type>deb8</docker.os_type>
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
+        <!-- Versions-->
+        <ubi.image.version>8.3-298</ubi.image.version>
+        <!-- Redhat Package Versions -->
+        <ubi.openssl.version>1.1.1g-15.el8_3</ubi.openssl.version>
+        <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
+        <ubi.netcat.version>7.70-5.el8</ubi.netcat.version>
+        <ubi.python36.version>3.6.8-2.module+el8.1.0+3334+5cb623d7</ubi.python36.version>
+        <ubi.tar.version>1.30-5.el8</ubi.tar.version>
+        <ubi.procps.version>3.3.15-3.el8</ubi.procps.version>
+        <ubi.krb5.workstation.version>1.18.2-5.el8</ubi.krb5.workstation.version>
+        <ubi.iputils.version>20180629-2.el8</ubi.iputils.version>
+        <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
+        <!-- ZULU OpenJDK Package Version -->
+        <ubi.zulu.openjdk.version>8.40.0.25</ubi.zulu.openjdk.version>
+        <!-- Python Module Versions -->
+        <ubi.python.pip.version>21.*</ubi.python.pip.version>
+        <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.43</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update avaibilbe to be installed. This is an inverted name since we're being clever
         with bash's || {true,false} check to fail the build. If this is false: This will fail a build if a security update

--- a/pom.xml
+++ b/pom.xml
@@ -29,5 +29,12 @@
         <docker.os_type>deb8</docker.os_type>
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
+        <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
+        detects that there is security update avaibilbe to be installed. This is an inverted name since we're being clever
+        with bash's || {true,false} check to fail the build. If this is false: This will fail a build if a security update
+        is detected. If true, then the check will not impact the build. The default beahvior is to fail (false) the build
+        if an update is detected. Users may pass -Ddocker.dont.fail.if.security.update.availible=true on the maven CLI
+        to bypass this check and make the build complete, despit that being a bad idea. Use at your own risk!-->
+        <docker.dont.fail.if.security.update.availible>false</docker.dont.fail.if.security.update.availible>
     </properties>
 </project>


### PR DESCRIPTION
This does a few things:

* Pins versions of packages we install from Redhat for reproducible builds
* Add check in Dockerfile to fail the build if the package manager detects any available security updates are available.
* Add an "escape hatch" for the above feature in the event you want to build a container thats not going to pass security scans.

I managed to test point 2 by removing the `--security` (because there were non-security updates) switch and built - Indeed the build fails, but would pass if I specified `-Ddocker.dont.fail.if.security.update.availible=true` on the maven CLI.