### PR TITLE
ST-4106: Uplift metrics related jars to CP Images

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -67,6 +67,11 @@ RUN microdnf install yum \
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 
+# Operator dependencies for metrics integration
+RUN mkdir -p /opt/javaagents
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/jolokia-jvm-*-agent.jar /opt/javaagents/.
+ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/jmx_prometheus_javaagent-*.jar /opt/javaagents/.
+
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 
 RUN mkdir /licenses

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -67,11 +67,6 @@ RUN microdnf install yum \
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 
-# Operator dependencies for metrics integration
-RUN mkdir -p /opt/javaagents
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/jolokia-jvm-*-agent.jar /opt/javaagents/.
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/jmx_prometheus_javaagent-*.jar /opt/javaagents/.
-
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 
 RUN mkdir /licenses

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -58,6 +58,20 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Operator dependencies for metrics integration -->
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-jvm</artifactId>
+            <version>${jolokia-jvm.version}</version>
+            <classifier>agent</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus.jmx</groupId>
+            <artifactId>jmx_prometheus_javaagent</artifactId>
+            <version>${jmx_prometheus_javaagent.version}</version>
+        </dependency>
     </dependencies>
 
       <!-- This jar is only used by the deb8 base image and does not get added to the other images. -->


### PR DESCRIPTION
This commit adds jolokia & prometheus java agents as
dependency to CP base and adds relevant jars to the
docker image.

Relevant updates to `common` (dependency): https://github.com/confluentinc/common/pull/322 (This change will need to be merged/built/deployed before we can get a passing PR build here)

(https://confluentinc.atlassian.net/browse/ST-4106)