### PR TITLE
ST-4106: Uplift metrics related jars to CP Images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ dockerfile {
     usePackages = true
     dockerRepos = ['confluentinc/cp-base-new', 'confluentinc/cp-jmxterm']
     slackChannel = '#tools-notifications'
-    mvnSkipDeploy = true
+    mvnSkipDeploy = false
     cron = ''
     cpImages = true
     osTypes = ['ubi8']

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>jmx_prometheus_javaagent</artifactId>
             <version>${jmx_prometheus_javaagent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>disk-usage-agent</artifactId>
+            <version>${io.confluent.common-docker.version}</version>
+        </dependency>
     </dependencies>
 
       <!-- This jar is only used by the deb8 base image and does not get added to the other images. -->

--- a/disk-usage-agent/pom.xml
+++ b/disk-usage-agent/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~
+  ~ Copyright 2021 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>common-docker</artifactId>
+        <version>6.2.0-0</version>
+    </parent>
+
+    <properties>
+    </properties>
+
+    <artifactId>disk-usage-agent</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Premain-Class>io.confluent.agent.monitoring.DiskUsage</Premain-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java
+++ b/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/DiskUsage.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.agent.monitoring;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+
+public class DiskUsage {
+  private static final Logger log = LoggerFactory.getLogger(DiskUsage.class);
+
+  public static void premain(String configfile, Instrumentation instrumentation) {
+
+    log.info("DiskUsage Agent: config : " + configfile);
+    try {
+      if (configfile != null && !configfile.isEmpty()) {
+        Map<String, String> config = loadConfig(configfile);
+        String serviceName = config.get("service.name");
+        Map<String, String> dirs = config.entrySet().stream()
+            .filter(map -> map.getKey().startsWith("disk."))
+            .collect(Collectors.toMap(p -> p.getKey(), p -> p.getValue()));
+
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+
+        for (String dir : dirs.keySet()) {
+          String displayName = dir.replace("disk.", "");
+          String volume = dirs.get(dir);
+
+          String objectName = String.format("io.confluent.caas:type=VolumeMetrics, service=%s, dir=%s", serviceName, displayName);
+          ObjectName volumeMBeanName = new ObjectName(objectName);
+
+          Volume volumeMBean = new Volume(volume);
+          server.registerMBean(volumeMBean, volumeMBeanName);
+
+          Set<ObjectInstance> instances = server.queryMBeans(new ObjectName(objectName), null);
+          ObjectInstance instance = (ObjectInstance) instances.toArray()[0];
+
+          log.info("DiskUsage Agent: Registering object :" + instance.getObjectName() + " for class : " + instance.getClassName());
+
+          log.info("DiskUsage Agent: Ping " + volumeMBean.toString());
+        }
+      } else {
+        log.error("Disk Agent: No config file provided.");
+      }
+    } catch (Exception e) {
+      log.error("Error while running Disk Agent: ", e);
+    }
+  }
+
+  public static Map loadConfig(String configFile) throws IOException {
+    if (!Files.exists(Paths.get(configFile))) {
+      throw new RuntimeException("The config file location is invalid. " + configFile);
+    }
+    final Properties cfg = new Properties();
+    try (InputStream inputStream = new FileInputStream(configFile)) {
+      cfg.load(inputStream);
+    }
+    return new HashMap<>(cfg);
+  }
+
+  public static void agentmain(String agentArguments, Instrumentation instrumentation) {
+    premain(agentArguments, instrumentation);
+  }
+
+  public static void main(String... args) throws InterruptedException {
+    if (args.length == 1) {
+      premain(args[0], null);
+    } else {
+      System.out.println("Need to provide path to config");
+    }
+  }
+
+}

--- a/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java
+++ b/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/Volume.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.agent.monitoring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class Volume implements VolumeMBean {
+  private static final Logger log = LoggerFactory.getLogger(Volume.class);
+
+  private final String dir;
+  private final FileStore store;
+
+  public Volume(String dir) throws IOException {
+    this.dir = dir;
+    store = Files.getFileStore(Paths.get(dir));
+  }
+
+  @Override
+  public long getTotal() {
+    long total = -1;
+    try {
+      total = this.store.getTotalSpace();
+    } catch (IOException e) {
+      log.error("Error while getting total disk space", e);
+    }
+    return total;
+  }
+
+  @Override
+  public long getUsed() {
+    long used = -1;
+    try {
+      used = (this.store.getTotalSpace() - this.store.getUnallocatedSpace());
+    } catch (IOException e) {
+      log.error("Error while getting total disk space", e);
+    }
+    return used;
+  }
+
+  @Override
+  public long getAvailable() {
+    long avail = -1;
+    try {
+      avail = this.store.getUsableSpace();
+    } catch (IOException e) {
+      log.error("Error while getting total disk space", e);
+    }
+    return avail;
+  }
+
+  @Override
+  public double getPercentUsed() {
+    return ((double)this.getUsed() / (double)this.getTotal()) * 100;
+  }
+
+  @Override
+  public double getPercentAvailable() {
+    return ((double)this.getAvailable() / (double)this.getTotal()) * 100;
+  }
+
+  @Override
+  public String getMountpoint() {
+    return dir;
+  }
+
+  @Override
+  public String getDeviceName() {
+    return this.store.name();
+  }
+
+  @Override
+  public String toString() {
+    return "Volume{" +
+        "store=" + store.toString() +
+        ", total=" + getTotal() +
+        ", used=" + getUsed() +
+        ", available=" + getAvailable() +
+        ", percentUsed=" + getPercentUsed() +
+        ", percentAvailable=" + getPercentAvailable() +
+        ", mountpoint='" + getMountpoint() + '\'' +
+        ", deviceName='" + getDeviceName() + '\'' +
+        '}';
+  }
+
+}

--- a/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/VolumeMBean.java
+++ b/disk-usage-agent/src/main/java/io/confluent/agent/monitoring/VolumeMBean.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.agent.monitoring;
+
+public interface VolumeMBean {
+
+  long getTotal();
+
+  long getUsed();
+
+  long getAvailable();
+
+  double getPercentUsed();
+
+  double getPercentAvailable();
+
+  String getMountpoint();
+
+  String getDeviceName();
+}

--- a/disk-usage-agent/src/test/java/io/confluent/agent/monitoring/VolumeTest.java
+++ b/disk-usage-agent/src/test/java/io/confluent/agent/monitoring/VolumeTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.agent.monitoring;
+
+import org.junit.Test;
+import org.junit.Ignore;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class VolumeTest {
+
+  @Ignore @Test
+  public void testVolume() {
+
+    try {
+      Volume volume = new Volume(System.getProperty("java.io.tmpdir"));
+
+      long total = volume.getTotal();
+      long used = volume.getUsed();
+      long available = volume.getAvailable();
+      double percentAvailable = volume.getPercentAvailable();
+      double percentUsed = volume.getPercentUsed();
+
+      assertNotNull(volume.getDeviceName());
+      assertEquals(volume.getMountpoint(), System.getProperty("java.io.tmpdir"));
+
+      assertTrue( total > 0);
+      assertTrue(used > 0);
+      assertTrue(available > 0);
+      assertEquals(total, used + available, total * 0.05);
+
+      assertTrue(percentAvailable > 0);
+      assertTrue(percentUsed > 0);
+      assertEquals(100.0, percentUsed + percentAvailable, 0.2);
+    } catch (IOException e) {
+      fail("Should not fail.");
+    }
+  }
+
+  @Test
+  public void testDiskUsage() {
+
+    try {
+      TemporaryFolder tempFolder = new TemporaryFolder();
+      String config = "service.name=kafka\ndisk.logs=/tmp";
+      tempFolder.create();
+      final File tempFile = tempFolder.newFile("test.properties");
+      Files.write(tempFile.toPath(), config.getBytes());
+      DiskUsage.premain(tempFile.getAbsolutePath(), null);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Should not fail.");
+    }
+  }
+}

--- a/disk-usage-agent/src/test/resources/log4j.properties
+++ b/disk-usage-agent/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=DEBUG,stderr
+
+# Only log errors from Kafka and ZKClient
+#log4j.logger.io.confluent.agent.monitoring=DEBUG, stderr
+
+# STDERR Appender
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout.ConversionPattern=%m%n

--- a/disk-usage-agent/src/test/resources/test.properties
+++ b/disk-usage-agent/src/test/resources/test.properties
@@ -1,0 +1,2 @@
+service.name=kafka
+disk.logs=/tmp

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <module>base</module>
         <module>jmxterm</module>
         <!-- <module>kerberos</module> -->
+        <module>disk-usage-agent</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Add disk-usage-agent

Migrate https://github.com/confluentinc/cc-docker-base/tree/master/disk-usage-agent to `common-docker` so we can add `disk-usage-agent.jar` as dependency (to be accessed from artifactory) for `common-docker/base` (and also use it for `cc-docker-base`) as part of the request in ST-4106.