### PR TITLE
ST-5293: Cleanup of netty version property

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -40,7 +40,6 @@
         <argparse4j.version>0.7.0</argparse4j.version>
         <bcpkix.version>1.54</bcpkix.version>
         <gson.version>2.7</gson.version>
-        <netty.version>4.1.63.Final</netty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This netty version property is now defined in common so no need to have it defined here as well.