### PR TITLE
ST-4106: Uplift metrics related jars to CP Images

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -72,6 +72,12 @@
             <artifactId>jmx_prometheus_javaagent</artifactId>
             <version>${jmx_prometheus_javaagent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>disk-usage-agent</artifactId>
+            <version>${io.confluent.common.version}</version>
+        </dependency>
     </dependencies>
 
       <!-- This jar is only used by the deb8 base image and does not get added to the other images. -->


### PR DESCRIPTION
Add disk-usage-agent as a dependency only

Follow up to https://github.com/confluentinc/common-docker/pull/134