### PR TITLE
build: Update pinned dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,16 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.3-298</ubi.image.version>
+        <ubi.image.version>8.4-200</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1g-15.el8_3</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-5.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-2.module+el8.1.0+3334+5cb623d7</ubi.python36.version>
         <ubi.tar.version>1.30-5.el8</ubi.tar.version>
-        <ubi.procps.version>3.3.15-3.el8_3.1</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-5.el8</ubi.krb5.workstation.version>
-        <ubi.iputils.version>20180629-2.el8</ubi.iputils.version>
+        <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
+        <ubi.krb5.workstation.version>1.18.2-8.el8</ubi.krb5.workstation.version>
+        <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.40.0.25</ubi.zulu.openjdk.version>


### PR DESCRIPTION
- Ubi base image version
- Versions of packaegs: procps, krb5-workstation & iputils

Docker Build for this image is failing:

```
02:53:56  [INFO] No match for argument: procps-ng-3.3.15-3.el8_3.1
02:53:56  [INFO] No match for argument: krb5-workstation-1.18.2-5.el8
02:53:56  [INFO] No match for argument: iputils-20180629-2.el8
02:53:56  [INFO] Error: Unable to find a match: procps-ng-3.3.15-3.el8_3.1 krb5-workstation-1.18.2-5.el8 iputils-20180629-2.el8
```

So I loaded up the container, saw there was a base image update to 8.4-200, checked the latest versions available, and updated the defined versions accordingly. 

Its not clear to me why Redhat stripped released software from their repos, when we were pinning to the 8.3 release, so 🤷 - I'll open a support case with them to see what they say, but we need to press forward.