### PR TITLE
build: Remove security flag from yum update check to fail on any package update

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -97,13 +97,13 @@ RUN microdnf install yum \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && chown appuser:appuser -R /etc/confluent/ /usr/logs
 
-# This is a step that will cause the build to fail of the package manager detects a security update is availible and isn't installed.
+# This is a step that will cause the build to fail of the package manager detects a package update is availible and isn't installed.
 # The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
 # is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the left
 # hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
 # security update is availible.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum check-update --security || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -101,7 +101,8 @@ RUN microdnf install yum \
 # The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
 # is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the left
 # hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
-# security update is availible.
+# security update is availible. We skip checks from ZuluJDK repos because Confluent pins those upstream versions for various reasons 
+# such as identified bugs in ZuluJDK's software.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
 RUN yum --disablerepo=zulu check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -103,7 +103,7 @@ RUN microdnf install yum \
 # hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
 # security update is availible.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum --disablerepo=zulu check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/


### PR DESCRIPTION
Redhat doesn't seem to be publishing erratas for their UBI image repos, so the `--security` flag isn't really doing anything in terms of the original intent - which is to fail the build if an update is found, but not installed. Case in point, the `glib2` update that propted this update https://github.com/confluentinc/common-docker/pull/138 didn't fail the build. Yet if we didn't have the `--security` flag, it would have worked. This change removes the flag so now the job will just fail if theres *any* update.