### PR TITLE
sec: Update UBI base image to 8.4-205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.4-200.1622548483</ubi.image.version>
+        <ubi.image.version>8.4-205</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1g-15.el8_3</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
New container revision 205 is out: https://catalog.redhat.com/software/containers/ubi8-minimal/5c64772edd19c77a158ea216?tag=8.4-205&push_date=1624986558000&container-tabs=overview

Build is blocked on consuming those updates:

```
11:42:15  [INFO] Step 35/42 : RUN yum --disablerepo=zulu check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
11:42:15  [INFO] 
11:42:15  [INFO]  ---> Running in b96cd8d34a94
11:42:15  [INFO] No repository match: zulu
11:42:15  [INFO] 
11:42:15  [INFO] Red Hat Universal Base Image 8 (RPMs) - BaseOS  7.4 MB/s | 786 kB     00:00    
11:42:16  [INFO] Red Hat Universal Base Image 8 (RPMs) - AppStre  18 MB/s | 2.4 MB     00:00    
11:42:16  [INFO] Red Hat Universal Base Image 8 (RPMs) - CodeRea 191 kB/s |  15 kB     00:00    
11:42:16  [INFO] zulu-openjdk - Azul Systems Inc., Zulu packages 2.2 MB/s | 177 kB     00:00    
11:42:17  [INFO] 
11:42:17  [INFO] libxml2.x86_64                    2.9.7-9.el8_4.2                   ubi-8-baseos
11:42:17  [INFO] lz4-libs.x86_64                   1.8.3-3.el8_4                     ubi-8-baseos
11:42:17  [INFO] openldap.x86_64                   2.4.46-17.el8_4                   ubi-8-baseos
11:42:17  [ERROR] The command '/bin/sh -c yum --disablerepo=zulu check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```