### PR TITLE
MINOR: Pin Zulu OpenJDK JRE Headless to 8.0.302

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -85,7 +85,7 @@ RUN microdnf install yum \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
         "iputils${IPUTILS_VERSION}" \
         "hostname${HOSTNAME_VERSION}" \
-        "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" \
+        "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" "zulu8-ca-jdk-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -73,8 +73,7 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
 
 RUN microdnf install yum \
-    && rpm --import http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems \
-    && curl -fSL -o /etc/yum.repos.d/zulu.repo http://repos.azulsystems.com/rhel/zulu.repo \
+    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
     && yum install -y --setopt=install_weak_deps=False \
         git \
         "openssl${OPENSSL_VERSION}" \
@@ -86,7 +85,7 @@ RUN microdnf install yum \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
         "iputils${IPUTILS_VERSION}" \
         "hostname${HOSTNAME_VERSION}" \
-        "zulu-8${ZULU_OPENJDK_VERSION}" \
+        "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>8.40.0.25</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>8.0.302</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
We want to consume a security update: https://www.oracle.com/security-alerts/cpujul2021.html


```
docker run -it placeholder/confluentinc/cp-base-new:5.4.5-SNAPSHOT-ubi8 java -version
openjdk version "1.8.0_302"
OpenJDK Runtime Environment (Zulu 8.56.0.21-CA-linux64) (build 1.8.0_302-b08)
OpenJDK 64-Bit Server VM (Zulu 8.56.0.21-CA-linux64) (build 25.302-b08, mixed mode)
```