### PR TITLE
build: Install v0.0.42-python2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -42,7 +42,7 @@ COPY requirements.txt .
 RUN apt update \
     && apt install -y bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
     && pip install --upgrade setuptools-git 'setuptools<51' 'pip<21' \
-    && pip install --prefix /usr/local --upgrade -rrequirements.txt \
+    && pip install --prefix /usr/local --upgrade 'git+https://github.com/confluentinc/confluent-docker-utils@v0.0.42-python2' \
     && apt remove --purge -y git python-pip \
     && apt autoremove -y \
     && rm -rf /var/lib/apt/lists/*     \


### PR DESCRIPTION
Confluent Docker Utils version 0.0.42-python2 strips some needless runtime dependencies.