### PR TITLE
doc: Fix checkstyle errors from checkstyle update

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2017 Confluent Inc.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -1,13 +1,13 @@
 /**
  * Copyright 2017 Confluent Inc.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and


### PR DESCRIPTION
PR https://github.com/confluentinc/common/pull/364 updated version of checkstyle, causing the build to fail on these linits:

```
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:3: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:3: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:7: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:7: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:9: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/ZookeeperConnectionWatcher.java:9: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:3: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:3: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:7: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:7: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:9: <p> tag should be placed immediately before the first word, with no space after. [JavadocParagraph]
15:53:09  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java:9: <p> tag should be preceded with an empty line. [JavadocParagraph]
15:53:09  Audit done.
```

Replicated issue locally, fixed locally. Test will be done in PR build.