### PR TITLE
build: QuorumPeer Changes for Zookeeper 3.6

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
@@ -54,7 +54,7 @@ public class EmbeddedZookeeperEnsemble {
   private int tickTime = 2000;
   private int initLimit = 3;
   private int syncLimit = 3;
-  private int connectToLearnerMasterLimit = 3;
+  private int connectToLearnerMasterLimit = initLimit;
   private boolean isRunning = false;
 
   private int numNodes;

--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java
@@ -54,6 +54,7 @@ public class EmbeddedZookeeperEnsemble {
   private int tickTime = 2000;
   private int initLimit = 3;
   private int syncLimit = 3;
+  private int connectToLearnerMasterLimit = 3;
   private boolean isRunning = false;
 
   private int numNodes;
@@ -93,7 +94,7 @@ public class EmbeddedZookeeperEnsemble {
       int portClient = basePort++;
       log.info("creating QuorumPeer " + i + " port " + portClient);
       QuorumPeer s = new QuorumPeer(peers, dir, dir, portClient, 3, i, tickTime, initLimit,
-                                    syncLimit
+                                    syncLimit, connectToLearnerMasterLimit
       );
       Assert.assertEquals(portClient, s.getClientPort());
 


### PR DESCRIPTION
This PR https://github.com/confluentinc/common/pull/371 's update of zookeeper has changed its `QuorumPeer` interface:

```
09:50:08  [INFO] -------------------------------------------------------------
09:50:08  [ERROR] COMPILATION ERROR : 
09:50:08  [INFO] -------------------------------------------------------------
09:50:08  [ERROR] /home/jenkins/workspace/onfluentinc_common-docker_master/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedZookeeperEnsemble.java:[95,22] no suitable constructor found for QuorumPeer(java.util.HashMap,java.io.File,java.io.File,int,int,int,int,int,int)
09:50:08      constructor org.apache.zookeeper.server.quorum.QuorumPeer.QuorumPeer() is not applicable
09:50:08        (actual and formal argument lists differ in length)
09:50:08      constructor org.apache.zookeeper.server.quorum.QuorumPeer.QuorumPeer(java.util.Map<java.lang.Long,org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer>,java.io.File,java.io.File,int,long,int,int,int,int,org.apache.zookeeper.server.ServerCnxnFactory) is not applicable
09:50:08        (actual and formal argument lists differ in length)
09:50:08      constructor org.apache.zookeeper.server.quorum.QuorumPeer.QuorumPeer(java.util.Map<java.lang.Long,org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer>,java.io.File,java.io.File,int,long,int,int,int,int,boolean,org.apache.zookeeper.server.ServerCnxnFactory,org.apache.zookeeper.server.quorum.flexible.QuorumVerifier) is not applicable
09:50:08        (actual and formal argument lists differ in length)
09:50:08      constructor org.apache.zookeeper.server.quorum.QuorumPeer.QuorumPeer(java.util.Map<java.lang.Long,org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer>,java.io.File,java.io.File,int,int,long,int,int,int,int) is not applicable
09:50:08        (actual and formal argument lists differ in length)
09:50:08      constructor org.apache.zookeeper.server.quorum.QuorumPeer.QuorumPeer(java.util.Map<java.lang.Long,org.apache.zookeeper.server.quorum.QuorumPeer.QuorumServer>,java.io.File,java.io.File,int,int,long,int,int,int,int,org.apache.zookeeper.server.quorum.flexible.QuorumVerifier) is not applicable
09:50:08        (actual and formal argument lists differ in length)
```

From reading 

* https://zookeeper.apache.org/doc/r3.6.0/apidocs/zookeeper-server/org/apache/zookeeper/server/quorum/QuorumPeer.html#connectToLearnerMasterLimit
* https://zookeeper.apache.org/doc/r3.6.1/zookeeperAdmin.html

The most logical value is to use what we pass to `initLimit`, so we do just that