### PR TITLE
doc: Add description label for all images

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -28,6 +28,7 @@ ENV ALLOW_UNSIGNED=$ALLOW_UNSIGNED
 
 MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
+LABEL description="Common base image for Confluent's Docker images."
 
 # Python
 ENV PYTHON_VERSION="2.7.9-1"

--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -29,6 +29,7 @@ LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
 MAINTAINER tools@confluent.io
 LABEL io.confluent.docker=true
+LABEL description="Common base image for Confluent's Docker images."
 
 # This affects how strings in Java class files are interpreted.  We want UTF-8 and this is the only locale in the
 # base image that supports it

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -33,6 +33,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="Common base image for Confluent's Docker images."
+LABEL description="Common base image for Confluent's Docker images."
 LABEL io.confluent.docker=true
 
 # This affects how strings in Java class files are interpreted.  We want UTF-8 and this is the only locale in the

--- a/jmxterm/Dockerfile.deb8
+++ b/jmxterm/Dockerfile.deb8
@@ -24,6 +24,7 @@ ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL description="Confluent Jmxterm Client"
 
 WORKDIR /opt
 

--- a/jmxterm/Dockerfile.deb9
+++ b/jmxterm/Dockerfile.deb9
@@ -24,6 +24,7 @@ ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL description="Confluent Jmxterm Client"
 
 WORKDIR /opt
 

--- a/jmxterm/Dockerfile.ubi8
+++ b/jmxterm/Dockerfile.ubi8
@@ -24,6 +24,7 @@ ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL description="Confluent Jmxterm Client"
 
 USER root
 WORKDIR /opt

--- a/kerberos/Dockerfile
+++ b/kerberos/Dockerfile
@@ -20,6 +20,7 @@ LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 LABEL io.confluent.docker=true
+LABEL description="Confluent Containerized KDC"
 
 # EPEL
 RUN yum install -y wget


### PR DESCRIPTION
Add unique description LABELs to the common-docker images. This was one of the findings from Redhat

This is a superficial change no testing is required.