### PR TITLE
fix: fix krb5-workstation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.1.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.4-208</ubi.image.version>
+        <ubi.image.version>8.4-210</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1g-15.el8_3</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <ubi.python36.version>3.6.8-2.module+el8.1.0+3334+5cb623d7</ubi.python36.version>
         <ubi.tar.version>1.30-5.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-8.el8</ubi.krb5.workstation.version>
+        <ubi.krb5.workstation.version>1.18.2-8.3.el8_4</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->


### PR DESCRIPTION
What:
Currently only krb5-workstation-1.18.2-8.3.el8_4 is available for ubi image https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/k/

Zulu repo is missing from current image

How:
Update base image
Update krb5-workstation

Test:
PR build successful.