### PR TITLE
build: Remove expired ca-cert

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -72,6 +72,9 @@ RUN echo "===> Updating debian ....." \
     && curl -fSL "https://bootstrap.pypa.io/pip/2.7/get-pip.py" | python \
     && pip install --no-cache-dir --prefix /usr/local --upgrade -rrequirements.txt \
     && apt remove --purge -y git \
+    # Expired cert blocking importing of GPG Keys
+    && rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt \
+    && update-ca-certificates \
     && echo "Installing Zulu OpenJDK ${ZULU_OPENJDK_VERSION}" \
     # https://docs.azul.com/zulu/zuludocs/ZuluUserGuide/PrepareZuluPlatform/AttachAPTRepositoryUbuntuOrDebianSys.htm
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \


### PR DESCRIPTION
This contains an expired cert thats blocking the ability to import GPG keys:

```
root@4c33dd1858d0:/# openssl x509 -in /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            44:af:b0:80:d6:a3:27:ba:89:30:39:86:2e:f8:40:6b
    Signature Algorithm: sha1WithRSAEncryption
        Issuer: O=Digital Signature Trust Co., CN=DST Root CA X3
        Validity
            Not Before: Sep 30 21:12:19 2000 GMT
            Not After : Sep 30 14:01:15 2021 GMT
```

Similar fix vended here: https://github.com/confluentinc/cp-docker-images/pull/907