### PR TITLE
build: Install updated Zulu JDK

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -106,7 +106,7 @@ RUN microdnf install yum \
 # security update is availible. We skip checks from ZuluJDK repos because Confluent pins those upstream versions for various reasons 
 # such as identified bugs in ZuluJDK's software.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum --disablerepo=zulu check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>8.0.302</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>8.0.312</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
Our upgrade-check is detecting / flagging that there is a JDK update. So we should install that newer JDK release for bug fixes & security updates.