### PR TITLE
build: Update UBI Base Image to 8.4-212

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.4-210</ubi.image.version>
+        <ubi.image.version>8.4-212</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1g-15.el8_3</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
Builds today were flagging that there are un-upgraded dependencies. Checking Redhat's UBI Image website

https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?container-tabs=packages

Indeed, there is a new base image revision `8.4-212` that is available.