### PR TITLE
feat: Add yum --nodocs to disable installing %doc files.

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -73,9 +73,9 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 # This can be overriden for an offline/air-gapped builds
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
 
-RUN microdnf install yum \
-    && yum -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
-    && yum install -y --setopt=install_weak_deps=False \
+RUN microdnf --nodocs install yum \
+    && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
+    && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
         "openssl${OPENSSL_VERSION}" \
         "wget${WGET_VERSION}" \
@@ -92,7 +92,7 @@ RUN microdnf install yum \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
     # Work around until Redhat releases updated base image
-    && yum update -y tzdata \
+    && yum --nodocs update -y tzdata \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \


### PR DESCRIPTION
This change makes it so any invocations of `yum` or `dnf` will skip installing any %doc tagged files from the base OS image (and Java vendor). This creates a smaller image overall as well as reduces false positives on security scans.

wrt to security scans for example, the `krb5-workstation` package is shipping a vulnerable `/usr/share/doc/krb5-workstation/_static/jquery-3.2.1.js` file, which isn't in code paths for CP, but is being picked up by security scanners. So instead of fighting this for every false positive that gets raised, we just disable installing all %doc files in the first place.