### PR TITLE
fix: Add default log4j.properties to utility-belt

### DIFF
--- a/utility-belt/src/main/resources/log4j.properties
+++ b/utility-belt/src/main/resources/log4j.properties
@@ -12,17 +12,17 @@
 # WARRANTIES OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
 #
+log4j.rootLogger=ERROR,stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
 # We chose DEBUG since this is helpful when troubleshooting launch
 # KafkaReadyCommand, TopicEnsureCommand, ZookeeperReadyCommand Commands.
 # These are short-lived checks before the service boots, so a little spam is "OK".
 # Having an "always-on" DEBUG logging level is also helpful in that users won't
 # need to "inject" their own DEBUG log4j.properties files into the container
 # to see why these checks are failing.
-log4j.rootLogger=ERROR,stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
-
 log4j.logger.io.confluent.admin.utils=DEBUG, stdout
 log4j.logger.kafka=WARN, stdout
 log4j.logger.org.apache.zookeeper=WARN, stdout

--- a/utility-belt/src/main/resources/log4j.properties
+++ b/utility-belt/src/main/resources/log4j.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2021 Confluent Inc.
+#
+# Licensed under the Confluent Community License (the "License"); you may not use
+# this file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+# http://www.confluent.io/confluent-community-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# We chose DEBUG since this is helpfull when troubleshooting launch
+# KafkaReadyCommand, TopicEnsureCommand, ZookeeperReadyCommand Commands.
+# These are short-lived checks before the service boots, so a little spam is "OK".
+# Having an "always-on" DEBUG logging level is also helpfull in that users won't
+# need to "inject" their own DEBUG log4j.properties files into the container
+# to see why these checks are failing.
+log4j.rootLogger=DEBUG,stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n

--- a/utility-belt/src/test/resources/log4j.properties
+++ b/utility-belt/src/test/resources/log4j.properties
@@ -11,13 +11,6 @@
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OF ANY KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations under the License.
-#
-# We chose DEBUG since this is helpfull when troubleshooting launch
-# KafkaReadyCommand, TopicEnsureCommand, ZookeeperReadyCommand Commands.
-# These are short-lived checks before the service boots, so a little spam is "OK".
-# Having an "always-on" DEBUG logging level is also helpfull in that users won't
-# need to "inject" their own DEBUG log4j.properties files into the container
-# to see why these checks are failing.
 log4j.rootLogger=ERROR,stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/utility-belt/src/test/resources/log4j.properties
+++ b/utility-belt/src/test/resources/log4j.properties
@@ -27,4 +27,3 @@ log4j.logger.io.confluent.admin.utils=DEBUG, stdout
 log4j.logger.kafka=WARN, stdout
 log4j.logger.org.apache.zookeeper=WARN, stdout
 log4j.logger.org.apache.kafka=WARN, stdout
-


### PR DESCRIPTION
This is another attempt at this change: https://github.com/confluentinc/common-docker/commit/3b75337ba3292f7364824bdf19ba1dbfd0fe6777 (thats since been rolled back due to it being incompatible with release-tools)

Without this change, this displays the issue from a proper image:

```
aegelhofer@Andrew-Egelhofer's- common-docker % docker run -it confluentinc/cp-base-new:latest cub kafka-ready 1 1 -b ....us-central1.gcp.confluent.cloud:9092
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-log4j12-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
log4j:WARN No appenders could be found for logger (io.confluent.admin.utils.cli.KafkaReadyCommand).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
aegelhofer@Andrew-Egelhofer's- common-docker %
```

Nothing helpful there, you can even see the WARN: `WARN Please initialize the log4j system properly.`. 

With this change (After building a local image):

```
aegelhofer@Andrew-Egelhofer's- common-docker % docker run -it 368821881613.dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new:dev-master-2006-ubi8 cub kafka-ready 1 1 -b ....us-central1.gcp.confluent.cloud:9092
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-log4j12-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
[2021-12-06 21:57:20,946] DEBUG Arguments Namespace(zookeeper_connect=null, min_expected_brokers=1, security_protocol=PLAINTEXT, config=null, bootstrap_servers=....us-central1.gcp.confluent.cloud:9092, timeout=1000).  (io.confluent.admin.utils.cli.KafkaReadyCommand:111)
[2021-12-06 21:57:20,952] DEBUG Check if Kafka is ready: {bootstrap.servers=....us-central1.gcp.confluent.cloud:9092} (io.confluent.admin.utils.ClusterStatus:135)
[2021-12-06 21:57:20,985] INFO AdminClientConfig values:
	bootstrap.servers = [....us-central1.gcp.confluent.cloud:9092]
	client.dns.lookup = use_all_dns_ips
	client.id =
	connections.max.idle.ms = 300000
...
[2021-12-06 21:57:23,248] INFO Expected 1 brokers but found only 0. Trying to query Kafka for metadata again ... (io.confluent.admin.utils.ClusterStatus:161)
[2021-12-06 21:57:23,249] ERROR Expected 1 brokers but found only 0. Brokers found []. (io.confluent.admin.utils.ClusterStatus:170)
```

We no longer see the log4j WARNs, as well as some more helpful DEBUG output.

This is also a "better" fix in that we're also providing this same "fix" to the TopicEnsure & ZookeeperReady commands.