### PR TITLE
fix: Initialize log4j in admin.utils Commands

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -193,6 +193,11 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <scope>compile</scope>
+         </dependency>
     </dependencies>
 
     <build>

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -103,7 +103,7 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
-
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -72,7 +72,7 @@ public class TopicEnsureCommand {
   }
 
   public static void main(String[] args) {
-
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -63,7 +63,7 @@ public class ZookeeperReadyCommand {
   }
 
   public static void main(String[] args) {
-
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success;
     try {


### PR DESCRIPTION
Abandoned approach here: https://github.com/confluentinc/common-docker/pull/169

Ever so slightly better approach from https://github.com/confluentinc/common-docker/commit/3b75337ba3292f7364824bdf19ba1dbfd0fe6777 - this time, we're not specifing a `<version>` block, so release-tools won't munge it when RCs are created. 

Testting (from a build on master, as it seems this issue only affects 7.0.0 images):

```
aegelhofer@Andrew-Egelhofer's- common-docker % docker run -it ....dkr.ecr.us-west-2.amazonaws.com/confluentinc/cp-base-new:dev-master-2006-ubi8 cub kafka-ready 1 1 -b ....gcp.confluent.cloud:9092
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-log4j12-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/usr/share/java/cp-base-new/slf4j-simple-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
0 [main] DEBUG io.confluent.admin.utils.cli.KafkaReadyCommand  - Arguments Namespace(zookeeper_connect=null, min_expected_brokers=1, security_protocol=PLAINTEXT, config=null, bootstrap_servers=....gcp.confluent.cloud:9092, timeout=1000).
4 [main] DEBUG io.confluent.admin.utils.ClusterStatus  - Check if Kafka is ready: {bootstrap.servers=....gcp.confluent.cloud:9092}
50 [main] INFO org.apache.kafka.clients.admin.AdminClientConfig  - AdminClientConfig values:
	bootstrap.servers = [...gcp.confluent.cloud:9092]
```