### PR TITLE
chore: Update openssl to 1.1.1k-5.el8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- Versions-->
         <ubi.image.version>8.5-204</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-4.el8</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-5.el8</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>


### PR DESCRIPTION
New release of openssl:

```
[root@c9689a661b56 /]# rpm -q --changelog openssl | head
* Fri Nov 12 2021 Sahana Prasad <sahana@redhat.com> - 1:1.1.1k-5
- CVE-2021-3712 openssl: Read buffer overruns processing ASN.1 strings
- Resolves: rhbz#2005400
```