### PR TITLE
update confluent-docker-utils to v0.0.49

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil==2.8.0
 setuptools<50.0.0
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.40
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.49


### PR DESCRIPTION
Updated confluent-docker-utils to latest version (v0.0.49).

This is a prerequisite for https://github.com/confluentinc/kafka-images/issues/92.