### PR TITLE
Add support for building on ARM64 (and Apple Silicon).

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -78,18 +78,18 @@ RUN microdnf --nodocs install yum \
     && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
-        "openssl${OPENSSL_VERSION}" \
-        "wget${WGET_VERSION}" \
-        "nmap-ncat${NETCAT_VERSION}" \
-        "python36${PYTHON36_VERSION}" \
-        "tar${TAR_VERSION}" \
-        "procps-ng${PROCPS_VERSION}" \
-        "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
-        "iputils${IPUTILS_VERSION}" \
-        "hostname${HOSTNAME_VERSION}" \
-        "zulu11-ca-jdk-headless${ZULU_OPENJDK_VERSION}" "zulu11-ca-jre-headless${ZULU_OPENJDK_VERSION}" \
+        "openssl-${OPENSSL_VERSION}" \
+        "wget-${WGET_VERSION}" \
+        "nmap-ncat-${NETCAT_VERSION}" \
+        "python36-${PYTHON36_VERSION}" \
+        "tar-${TAR_VERSION}" \
+        "procps-ng-${PROCPS_VERSION}" \
+        "krb5-workstation-${KRB5_WORKSTATION_VERSION}" \
+        "iputils-${IPUTILS_VERSION}" \
+        "hostname-${HOSTNAME_VERSION}" \
+        "zulu11-ca-jdk-headless-${ZULU_OPENJDK_VERSION}" "zulu11-ca-jre-headless-${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
-    && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
+    && python3 -m pip install --upgrade "pip==${PYTHON_PIP_VERSION}" "setuptools==${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
     # Work around until Redhat releases updated base image

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -109,26 +109,76 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>docker</executable>
+                            <workingDirectory>${project.basedir}</workingDirectory>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-f</argument>
+                                <argument>Dockerfile.ubi8</argument>
+                                <argument>--build-arg</argument>
+                                <argument>UBI_MINIMAL_VERSION=${ubi.image.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>OPENSSL_VERSION=${ubi.openssl.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>WGET_VERSION=${ubi.wget.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>NETCAT_VERSION=${ubi.netcat.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PYTHON36_VERSION=${ubi.python36.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>TAR_VERSION=${ubi.tar.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PROCPS_VERSION=${ubi.procps.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>KRB5_WORKSTATION_VERSION=${ubi.krb5.workstation.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>IPUTILS_VERSION=${ubi.iputils.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>HOSTNAME_VERSION=${ubi.hostname.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>ZULU_OPENJDK_VERSION=${ubi.zulu.openjdk.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PYTHON_PIP_VERSION=${ubi.python.pip.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PYTHON_SETUPTOOLS_VERSION=${ubi.python.setuptools.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PYTHON_CONFLUENT_DOCKER_UTILS_VERSION=${ubi.python.confluent.docker.utils.version}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>SKIP_SECURITY_UPDATE_CHECK=${docker.skip-security-update-check}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>ARTIFACT_ID=${project.artifactId}</argument>
+                                <argument>--build-arg</argument>
+                                <argument>PROJECT_VERSION=${project.version}</argument>
+                                <argument>-t</argument>
+                                <argument>${docker.registry}confluentinc/${project.artifactId}:${docker.tag}</argument>
+                                <argument>.</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
                 <configuration>
-                    <buildArgs>
-                        <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
-                        <OPENSSL_VERSION>-${ubi.openssl.version}</OPENSSL_VERSION>
-                        <WGET_VERSION>-${ubi.wget.version}</WGET_VERSION>
-                        <NETCAT_VERSION>-${ubi.netcat.version}</NETCAT_VERSION>
-                        <PYTHON36_VERSION>-${ubi.python36.version}</PYTHON36_VERSION>
-                        <TAR_VERSION>-${ubi.tar.version}</TAR_VERSION>
-                        <PROCPS_VERSION>-${ubi.procps.version}</PROCPS_VERSION>
-                        <KRB5_WORKSTATION_VERSION>-${ubi.krb5.workstation.version}</KRB5_WORKSTATION_VERSION>
-                        <IPUTILS_VERSION>-${ubi.iputils.version}</IPUTILS_VERSION>
-                        <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
-                        <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
-                        <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
-                        <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
-                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${ubi.python.confluent.docker.utils.version}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
-                        <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
-                    </buildArgs>
+                    <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.0.1</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.5-204</ubi.image.version>
+        <ubi.image.version>8.5-230.1645809059</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-4.el8</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-5.el8_5</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>
@@ -44,7 +44,7 @@
         <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.13</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.14.1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
From my testing, I was able to build Confluent ZK and Kafka images using the changes here as the base image and it seemed to run fine, natively, on an Apple M1 machine. 

This would resolve https://github.com/confluentinc/common-docker/issues/117 and https://github.com/confluentinc/kafka-images/issues/80.

**NOTE**: Probably the PR on this branch isn't the best, but I was unable to test locally against any newer versions as the various Confluent artifacts for versions `> 7.0.1` were not found in https://packages.confluent.io/maven/.

## Changes

* Update Zulu version to multiarch (ARM supported one)
* Remove dockerfile-maven-plugin building -- there is an upstream issue with building on ARM (FFI issue https://github.com/spotify/dockerfile-maven/issues/367)

## Testing

I pushed the base, ZK, and Kafka images if you want to test:

* `chrismoos/cp-kafka:7.0.1`
* `chrismoos/cp-base-new:7.0.1-ubi8`
* `chrismoos/cp-zookeeper:7.0.1`
