### PR TITLE
build: Update base image to 8.5-240

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.5-230.1645809059</ubi.image.version>
+        <ubi.image.version>8.5-240</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-5.el8_5</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
Update image revision to latest ubi-minimal image version, 8.5-240

To be cherry picked into 5.4.0-post after, then pint merged up