### PR TITLE
Update ubi.openssl.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <!-- Versions-->
         <ubi.image.version>8.5-240</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-5.el8_5</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>


### PR DESCRIPTION
`common-docker` builds are [failing](https://jenkins.confluent.io/job/confluentinc/job/common-docker/job/7.0.x/350/consoleFull) because RedHat took down an older release version instead of leaving it up for pinned dependencies 🙄
```
No match for argument: openssl-1.1.1k-5.el8_5
22:25:22  [INFO] Error: Unable to find a match: openssl-1.1.1k-5.el8_5
```

Following troubleshooting steps here: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker

Loaded up the base image `redhat/ubi8-minimal:8.5-240`, ran a `yum list --showduplicates openssl`, and found that there is an update to `openssl-1.1.1k-6.el8_5` available.

To be merged into -post and .x branches