### PR TITLE
Migrate log4j to reload4j

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -76,6 +76,17 @@
             <groupId>io.confluent</groupId>
             <artifactId>disk-usage-agent</artifactId>
             <version>${io.confluent.common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>logredactor</artifactId>
         </dependency>
     </dependencies>
 

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -85,6 +85,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>logredactor</artifactId>
         </dependency>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -110,7 +110,11 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-codec</artifactId>
                 </exclusion>
-            </exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion> 
+            </exclusions>           
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -219,11 +223,16 @@
             <scope>test</scope>
         </dependency>
 
-         <dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
-            <scope>compile</scope>
-         </dependency>
+            <artifactId>logredactor</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Description
This is a request to migrate from confluent-log4j to reload4j

Jira Ticket:
DP-7573

Resolution
Step 1: Replace slf4j-log4j12 with slf4j-reload4j.jar
Step 2: Remove Confluent-log4j
Step 3: Add dependency on Logredactor
