### PR TITLE
[chore] Update iputils to 20180629-9.el8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.5-243.1651231653</ubi.image.version>
+        <ubi.image.version>8.6-751</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <ubi.tar.version>1.30-5.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-14.el8</ubi.krb5.workstation.version>
-        <ubi.iputils.version>20180629-7.el8</ubi.iputils.version>
+        <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.0.332-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
```
11:26:17  [INFO] zulu-openjdk - Azul Systems Inc., Zulu packages 3.0 MB/s | 348 kB     00:00    
11:26:17  [INFO] No match for argument: iputils-20180629-7.el8
11:26:17  [INFO] [91mError: Unable to find a match: iputils-20180629-7.el8
```

Following troubleshooting instructions in https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker

Loaded up base image with `docker run -it redhat/ubi8-minimal:8.5-243.1651231653`, ran `yum list --showduplicates iputils`, and it showed that there's an update to iputils and latest version should be `20180629-9.el8`

To be pint merged into `-post` and `.x` branches

**EDIT:**  Initial PR build failed on `RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"`, this is the other use case documented in the same doc above. Resolution: update UBI base image to 8.6-751, the latest here https://hub.docker.com/r/redhat/ubi8-minimal/tags