### PR TITLE
Remove team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 *	@confluentinc/tools
-*	@confluentinc/team 


### PR DESCRIPTION
This repo is owned by tools, removing @/team to reduce noise
To be pint merged up to master