### PR TITLE
[chore] Bump confluent-docker-utils to v0.0.52

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.51
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.52

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.49</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.52</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
Bump confluent-docker-utils to v0.0.52

To be pint merged up through master