### PR TITLE
Add xz-libs to yum installs, since it is not defaulted to the latest …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 *.iml
 .idea/
 .ipr
+
+.vscode/

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -59,6 +59,7 @@ ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
 ARG IPUTILS_VERSION=""
 ARG HOSTNAME_VERSION=""
+ARG XZ_LIBS_VERSION=""
 
 # Zulu OpenJDK version
 ARG ZULU_OPENJDK_VERSION=""
@@ -86,6 +87,7 @@ RUN microdnf --nodocs install yum \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
         "iputils${IPUTILS_VERSION}" \
         "hostname${HOSTNAME_VERSION}" \
+        "xz-libs${XZ_LIBS_VERSION}" \
         "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" "zulu8-ca-jdk-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -103,6 +103,7 @@
                         <KRB5_WORKSTATION_VERSION>-${ubi.krb5.workstation.version}</KRB5_WORKSTATION_VERSION>
                         <IPUTILS_VERSION>-${ubi.iputils.version}</IPUTILS_VERSION>
                         <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
+                        <XZ_LIBS_VERSION>-${ubi.xzlibs.version}</XZ_LIBS_VERSION>
                         <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
                         <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <ubi.krb5.workstation.version>1.18.2-14.el8</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
+        <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.0.332-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
…version on the base image

Failed common-docker build: https://jenkins.confluent.io/job/confluentinc/job/common-docker/job/5.4.x/1237/console

Following the instructions at: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker