### PR TITLE
update glibc package

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -60,6 +60,7 @@ ARG KRB5_WORKSTATION_VERSION=""
 ARG IPUTILS_VERSION=""
 ARG HOSTNAME_VERSION=""
 ARG XZ_LIBS_VERSION=""
+ARG GLIBC_VERSION=""
 
 # Zulu OpenJDK version
 ARG ZULU_OPENJDK_VERSION=""
@@ -88,6 +89,9 @@ RUN microdnf --nodocs install yum \
         "iputils${IPUTILS_VERSION}" \
         "hostname${HOSTNAME_VERSION}" \
         "xz-libs${XZ_LIBS_VERSION}" \
+        "glibc${GLIBC_VERSION}" \
+        "glibc-common${GLIBC_VERSION}" \
+        "glibc-minimal-langpack${GLIBC_VERSION}" \
         "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" "zulu8-ca-jdk-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -104,6 +104,7 @@
                         <IPUTILS_VERSION>-${ubi.iputils.version}</IPUTILS_VERSION>
                         <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
                         <XZ_LIBS_VERSION>-${ubi.xzlibs.version}</XZ_LIBS_VERSION>
+                        <GLIBC_VERSION>-${ubi.glibc.version}</GLIBC_VERSION>
                         <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
                         <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
+        <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.0.332-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
```
04:35:21  [INFO]  ---> Running in f3e8823273cf
04:35:21  [INFO] Red Hat Universal Base Image 8 (RPMs) - BaseOS  2.9 MB/s | 783 kB     00:00    
04:35:22  [INFO] Red Hat Universal Base Image 8 (RPMs) - AppStre  19 MB/s | 3.0 MB     00:00    
04:35:22  [INFO] Red Hat Universal Base Image 8 (RPMs) - CodeRea 208 kB/s |  18 kB     00:00    
04:35:22  [INFO] zulu-openjdk - Azul Systems Inc., Zulu packages 3.5 MB/s | 348 kB     00:00    
04:35:23  [INFO] 
04:35:23  [INFO] glibc.x86_64                            2.28-189.5.el8_6            ubi-8-baseos
04:35:23  [INFO] glibc-common.x86_64                     2.28-189.5.el8_6            ubi-8-baseos
04:35:23  [INFO] glibc-minimal-langpack.x86_64           2.28-189.5.el8_6            ubi-8-baseos
04:35:23  [ERROR] The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```

https://jenkins.confluent.io/job/confluentinc/job/common-docker/job/5.4.x/1243/console