### PR TITLE
chore: update base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.6-751.1655117800</ubi.image.version>
+        <ubi.image.version>8.6-854</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
common-docker builds failing: 
https://confluentinc.atlassian.net/browse/DP-8093
https://confluentinc.atlassian.net/browse/DP-8094
https://confluentinc.atlassian.net/browse/DP-8096

Error:
`[ERROR] The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1`

Resolution: 
Update redhat ubi base image
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker

5.4.x pint merge to master; skipping 5.3.x (uses `azul/zulu-openjdk-debian:8u242`) since it does not use redhat ubi image