### PR TITLE
Use COPY instead of ADD

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -116,8 +116,8 @@ RUN microdnf --nodocs install yum \
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
 RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-ADD --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 


### PR DESCRIPTION
Changes two uses of ADD to COPY in the Dockerfile. The additional features of ADD (tar unpacking and remote URL support) aren't used here so they are functionally equivalent.

Otherwise this trips the CIS Docker Benchmark rule to [use COPY instead of ADD in the Dockerfile](https://github.com/goodwithtech/dockle/blob/ed895e7bd196edf1c76d328a26b652dbd9c114e2/CHECKPOINT.md#cis-di-0009).

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy