### PR TITLE
[chore] Update base image, openssl, and openjdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.6-854</ubi.image.version>
+        <ubi.image.version>8.6-902</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>
@@ -44,7 +44,7 @@
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>8.0.342-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>8.0.345-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
Build error:
```
zulu8-ca-jdk-headless.x86_64               8.0.342-1                zulu-openjdk
03:35:10  [INFO] zulu8-ca-jre-headless.x86_64               8.0.342-1                zulu-openjdk
03:35:10  [ERROR] The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```

Following troubleshooting steps https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-%7C%7C-%22$%7BSKIP_SECURITY_UPDATE_CHECK%7D%22'-returned-a-non-zero-code:-1in-common-docker

There is an available base image version update 8.6-902, as well as updates to latest openssl and openjdk versions available on it.

To be pint merged up (6.0.x+ will be using zulu11 `11.0.16-1`)
