### PR TITLE
Set cub default logging to info

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.impl;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +51,7 @@ import static net.sourceforge.argparse4j.impl.Arguments.store;
  */
 public class KafkaReadyCommand {
 
-  private static final Logger log = LoggerFactory.getLogger(KafkaReadyCommand.class);
+  private static Logger log;
   public static final String KAFKA_READY = "kafka-ready";
 
   private static ArgumentParser createArgsParser() {
@@ -103,8 +104,9 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
+    System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "INFO");
+    log = LoggerFactory.getLogger(KafkaReadyCommand.class);
     org.apache.log4j.BasicConfigurator.configure();
-    log.setLevel(org.apache.log4j.Level.INFO);
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -104,6 +104,7 @@ public class KafkaReadyCommand {
 
   public static void main(String[] args) {
     org.apache.log4j.BasicConfigurator.configure();
+    log.setLevel(org.apache.log4j.Level.INFO);
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {


### PR DESCRIPTION
**Context:**
For https://confluentinc.atlassian.net/browse/DP-8414

Right now, the default logging level in [confluent-docker-utils/cub.py at master](https://github.com/confluentinc/confluent-docker-utils/blob/master/confluent/docker_utils/cub.py#L160-L172)  is DEBUG. `cub` is a wrapper around calling Java with the `io.confluent.admin.utils.cli.KafkaReadyCommand` class. Investigation by appsec team showed that the 1.7.36 version of slf4j caused the logging level to default to DEBUG, potentially showing more information than is desired when `cub` is ran.

Appsec team has requested to change the logging level to INFO.

**Changes:** 
Specify INFO as the default logging level

To be merged up through master.