### PR TITLE
Remove slf4j-simple to avoid double binding with reload4j

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -47,12 +47,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/docker-utils/pom.xml
+++ b/docker-utils/pom.xml
@@ -55,6 +55,7 @@
             <artifactId>utility-belt</artifactId>
             <version>${io.confluent.common-docker.version}</version>
         </dependency>
+    </dependencies>
 
     <build>
         <plugins>

--- a/docker-utils/pom.xml
+++ b/docker-utils/pom.xml
@@ -56,13 +56,6 @@
             <version>${io.confluent.common-docker.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${slf4j-api.version}</version>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Context:
Starting in 7.2.x, common-docker brings in both `slf4j-simple` and `reload4j`, both of which are built on `slf4j-api`. As a result, we get a warning about multiple slf4j bindings when running our docker images. Further details at http://www.slf4j.org/codes.html#multiple_bindings for an explanation.

Changes:
This removes use of slf4j-simple in 7.2.x and up (where reload4j already exists) to avoid showing multiple binding warning in our images.