### PR TITLE
Configure loggers from log4j properties

### DIFF
--- a/docker-utils/main/resources/log4j.properties
+++ b/docker-utils/main/resources/log4j.properties
@@ -26,3 +26,4 @@ log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 log4j.appender.stderr.Target=System.err
 log4j.appender.stderr.layout.ConversionPattern=%m%n
+log4j.additivity.stderr=false

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -103,7 +103,7 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
+    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -103,7 +103,8 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
+    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
+    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -72,7 +72,8 @@ public class TopicEnsureCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
+    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
+    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -72,7 +72,7 @@ public class TopicEnsureCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
+    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -63,7 +63,8 @@ public class ZookeeperReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
+    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
+    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
     ArgumentParser parser = createArgsParser();
     boolean success;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -63,7 +63,7 @@ public class ZookeeperReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
+    org.apache.log4j.PropertyConfigurator.configure("/docker-utils/main/resources/log4j.properties");
     ArgumentParser parser = createArgsParser();
     boolean success;
     try {


### PR DESCRIPTION
**Context:**
For https://confluentinc.atlassian.net/browse/DP-8414

Right now, the shown logging level in [confluent-docker-utils/cub.py at master](https://github.com/confluentinc/confluent-docker-utils/blob/master/confluent/docker_utils/cub.py#L160-L172) is DEBUG. Investigation by appsec team showed that the 1.7.36 version of slf4j caused the logging level to default to DEBUG, potentially showing more information than is desired when cub is ran. cub is just a wrapper around calling Java with the `io.confluent.admin.utils.cli.KafkaReadyCommand` class, so we need to fix `KafkaReadyCommand` class here to not show DEBUG logs.

[This solution](https://stackoverflow.com/questions/2453010/log4j-rootlogger-seems-to-inherit-log-level-of-other-logger-why) suggests that we disable additivity to ensure that we are using the logging level that we specify. Also our current logger in `KafkaReadyCommand.java` configures an appender from default settings instead of using the settings in log4j properties.

**Changes:**
Update [log4j.properties](https://github.com/confluentinc/common-docker/blob/master/docker-utils/main/resources/log4j.properties) to disable additivity. Explicitly configure all loggers from the appender configuration specified in log4j.properties instead.

**Testing and Future Steps:**
Images pass local testing, but need to be fully built in CP ecosystem and validated with appsec team, then we can backport to `.x` branches.