### PR TITLE
fix: Pin curl and libcurl Versions

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -62,7 +62,6 @@ ARG HOSTNAME_VERSION=""
 ARG XZ_LIBS_VERSION=""
 ARG GLIBC_VERSION=""
 ARG CURL_VERSION=""
-ARG LIBCURL_VERSION=""
 
 # Zulu OpenJDK version
 ARG ZULU_OPENJDK_VERSION=""
@@ -95,7 +94,7 @@ RUN microdnf --nodocs install yum \
         "glibc-common${GLIBC_VERSION}" \
         "glibc-minimal-langpack${GLIBC_VERSION}" \
         "curl${CURL_VERSION}" \
-        "libcurl${LIBCURL_VERSION}" \
+        "libcurl${CURL_VERSION}" \
         "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" "zulu8-ca-jdk-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -61,6 +61,8 @@ ARG IPUTILS_VERSION=""
 ARG HOSTNAME_VERSION=""
 ARG XZ_LIBS_VERSION=""
 ARG GLIBC_VERSION=""
+ARG CURL_VERSION=""
+ARG LIBCURL_VERSION=""
 
 # Zulu OpenJDK version
 ARG ZULU_OPENJDK_VERSION=""
@@ -92,6 +94,8 @@ RUN microdnf --nodocs install yum \
         "glibc${GLIBC_VERSION}" \
         "glibc-common${GLIBC_VERSION}" \
         "glibc-minimal-langpack${GLIBC_VERSION}" \
+        "curl${CURL_VERSION}" \
+        "libcurl${LIBCURL_VERSION}" \
         "zulu8-ca-jre-headless${ZULU_OPENJDK_VERSION}" "zulu8-ca-jdk-headless${ZULU_OPENJDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}" \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -106,7 +106,6 @@
                         <XZ_LIBS_VERSION>-${ubi.xzlibs.version}</XZ_LIBS_VERSION>
                         <GLIBC_VERSION>-${ubi.glibc.version}</GLIBC_VERSION>
                         <CURL_VERSION>-${ubi.curl.version}</CURL_VERSION>
-                        <LIBCURL_VERSION>-${ubi.libcurl.version}</LIBCURL_VERSION>
                         <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
                         <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -105,6 +105,8 @@
                         <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
                         <XZ_LIBS_VERSION>-${ubi.xzlibs.version}</XZ_LIBS_VERSION>
                         <GLIBC_VERSION>-${ubi.glibc.version}</GLIBC_VERSION>
+                        <CURL_VERSION>-${ubi.curl.version}</CURL_VERSION>
+                        <LIBCURL_VERSION>-${ubi.libcurl.version}</LIBCURL_VERSION>
                         <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
                         <PYTHON_PIP_VERSION>==${ubi.python.pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,8 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>
+        <ubi.curl.version>7.61.1-22.el8_6.4</ubi.curl.version>
+        <ubi.libcurl.version>7.61.1-22.el8_6.4</ubi.libcurl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.0.345-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,6 @@
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>
         <ubi.curl.version>7.61.1-22.el8_6.4</ubi.curl.version>
-        <ubi.libcurl.version>7.61.1-22.el8_6.4</ubi.libcurl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>8.0.345-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
5.4.x and newer versions are failing due to:
```
03:40:43  [INFO] Step 38/45 : RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
03:40:43  [INFO] 
03:40:43  [INFO]  ---> Running in 6a6db3c2e676
03:40:43  [INFO] Red Hat Universal Base Image 8 (RPMs) - BaseOS  6.9 MB/s | 801 kB     00:00    
03:40:44  [INFO] Red Hat Universal Base Image 8 (RPMs) - AppStre  19 MB/s | 3.0 MB     00:00    
03:40:44  [INFO] Red Hat Universal Base Image 8 (RPMs) - CodeRea 246 kB/s |  20 kB     00:00    
03:40:44  [INFO] zulu-openjdk - Azul Systems Inc., Zulu packages 2.3 MB/s | 418 kB     00:00    
03:40:45  [INFO] 
03:40:45  [INFO] curl.x86_64                     7.61.1-22.el8_6.4                   ubi-8-baseos
03:40:45  [INFO] libcurl.x86_64                  7.61.1-22.el8_6.4                   ubi-8-baseos
03:40:45  [ERROR] The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
03:40:45  [INFO] ------------------------------------------------------------------------
03:40:45  [INFO] Reactor Summary for common-docker 5.4.10-SNAPSHOT:
03:40:45  [INFO] 
03:40:45  [INFO] common-docker ...................................... SUCCESS [ 24.709 s]
03:40:45  [INFO] utility-belt ....................................... SUCCESS [02:37 min]
03:40:45  [INFO] docker-utils ....................................... SUCCESS [ 10.665 s]
03:40:45  [INFO] cp-base-new ........................................ FAILURE [01:07 min]
03:40:45  [INFO] cp-jmxterm ......................................... SKIPPED
03:40:45  [INFO] ------------------------------------------------------------------------
03:40:45  [INFO] BUILD FAILURE
03:40:45  [INFO] ------------------------------------------------------------------------
03:40:45  [INFO] Total time:  04:21 min
03:40:45  [INFO] Finished at: 2022-08-25T10:40:45Z
03:40:45  [INFO] ------------------------------------------------------------------------
03:40:45  [INFO] [jenkins-event-spy] Generated /home/jenkins/workspace/confluentinc_common-docker_5.4.x@tmp/withMavend14c4e96/maven-spy-20220825-103624-302451879624309493376.log
03:40:45  [ERROR] Failed to execute goal com.spotify:dockerfile-maven-plugin:1.4.13:build (package) on project cp-base-new: Could not build image: The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1 -> [Help 1]
```

Solution: 
Install specific version of curl and libcurl. 