### PR TITLE
Revert "Configure loggers from log4j properties (#230)"

### DIFF
--- a/docker-utils/main/resources/log4j.properties
+++ b/docker-utils/main/resources/log4j.properties
@@ -26,4 +26,3 @@ log4j.appender.stderr=org.apache.log4j.ConsoleAppender
 log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
 log4j.appender.stderr.Target=System.err
 log4j.appender.stderr.layout.ConversionPattern=%m%n
-log4j.additivity.stderr=false

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -103,8 +103,7 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
-    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
-    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -72,8 +72,7 @@ public class TopicEnsureCommand {
   }
 
   public static void main(String[] args) {
-    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
-    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -63,8 +63,7 @@ public class ZookeeperReadyCommand {
   }
 
   public static void main(String[] args) {
-    String log4jConfigFile = "/docker-utils/main/resources/log4j.properties";
-    org.apache.log4j.PropertyConfigurator.configure(log4jConfigFile);
+    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success;
     try {


### PR DESCRIPTION
Revert configuring log4j via `log4j.properties`, as master:latest image is running into issues finding the properties file when attempting to run kafka ready. Unblock it for now until we have a fix.