### PR TITLE
DP-8414: Add default log4j property 

### DIFF
--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -103,7 +103,6 @@ public class KafkaReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/TopicEnsureCommand.java
@@ -72,7 +72,6 @@ public class TopicEnsureCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success = false;
     try {

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/ZookeeperReadyCommand.java
@@ -63,7 +63,6 @@ public class ZookeeperReadyCommand {
   }
 
   public static void main(String[] args) {
-    org.apache.log4j.BasicConfigurator.configure();
     ArgumentParser parser = createArgsParser();
     boolean success;
     try {

--- a/utility-belt/src/main/resources/log4j.properties
+++ b/utility-belt/src/main/resources/log4j.properties
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=OFF
+
+# Only log errors from Kafka and ZKClient
+log4j.logger.org.apache.kafka=ERROR
+log4j.logger.org.I0Itec.zkclient.ZkClient=ERROR
+
+# Log informational messages from the CLI and Zookeeper
+log4j.logger.io.confluent.admin.utils=INFO, stderr
+log4j.logger.org.apache.zookeeper=INFO, stderr
+# STDERR Appender
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.Target=System.err
+log4j.appender.stderr.layout.ConversionPattern=%m%n


### PR DESCRIPTION
- Introduce default config at INFO level for utility command. 

https://confluentinc.atlassian.net/browse/DP-6627?focusedCommentId=736032

