### PR TITLE
[chore] Bump confluent-docker-utils to v0.0.53

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.52
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.53

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>50.*</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.52</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.53</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
Bump confluent-docker-utils version for branches 6.0.x+ (5.4.x or 5.5.x are [intentionally pinned to older version](https://github.com/confluentinc/common-docker/blob/5.5.x/base/requirements.txt) that supports the older frameworks)