### PR TITLE
Remove jolokia jvm agent

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -64,7 +64,6 @@
             <groupId>org.jolokia</groupId>
             <artifactId>jolokia-jvm</artifactId>
             <version>${jolokia-jvm.version}</version>
-            <classifier>agent</classifier>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Description:
Common repo just updated 7.0.x and 7.1.x jolokia versions to 1.7.1. and jolokai 1.7.1 comes with a backward incompatible change. remove the agent tag.  