### PR TITLE
Update openssl version for hotfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- Versions-->
         <ubi.image.version>8.6-854</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>


### PR DESCRIPTION
Steps taken:
1. [cp-docker-images-overlay/6.2.6-cp1](https://jenkins.confluent.io/job/confluentinc/job/cp-docker-images-overlay/job/6.2.6-cp1-rc221011031148/) was failing on common-docker build
2. [common-docker build](https://jenkins.confluent.io/job/confluentinc/job/common-docker/job/6.2.6-cp1-rc221011031148/2/console) was failing on following error
```02:23:36  [INFO] No match for argument: openssl-1.1.1k-6.el8_5
02:23:36  [INFO] Package xz-libs-5.2.4-4.el8_6.x86_64 is already installed.
02:23:36  [INFO] Package glibc-2.28-189.5.el8_6.x86_64 is already installed.
02:23:36  [INFO] Package glibc-common-2.28-189.5.el8_6.x86_64 is already installed.
02:23:36  [INFO] Package glibc-minimal-langpack-2.28-189.5.el8_6.x86_64 is already installed.
02:23:36  [INFO] Error: Unable to find a match: openssl-1.1.1k-6.el8_5
02:23:36  [INFO] 
02:23:36  [ERROR] The command '/bin/sh -c microdnf --nodocs install yum     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt     && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm     && yum --nodocs install -y --setopt=install_weak_deps=False         git         "openssl${OPENSSL_VERSION}"         "wget${WGET_VERSION}"         "nmap-ncat${NETCAT_VERSION}"         "python36${PYTHON36_VERSION}"         "tar${TAR_VERSION}"         "procps-ng${PROCPS_VERSION}"         "krb5-workstation${KRB5_WORKSTATION_VERSION}"         "iputils${IPUTILS_VERSION}"         "hostname${HOSTNAME_VERSION}"         "xz-libs${XZ_LIBS_VERSION}"         "glibc${GLIBC_VERSION}"         "glibc-common${GLIBC_VERSION}"         "glibc-minimal-langpack${GLIBC_VERSION}"         "zulu11-ca-jdk-headless${ZULU_OPENJDK_VERSION}" "zulu11-ca-jre-headless${ZULU_OPENJDK_VERSION}"     && alternatives --set python /usr/bin/python3     && python3 -m pip install --upgrade "pip${PYTHON_PIP_VERSION}" "setuptools${PYTHON_SETUPTOOLS_VERSION}"     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}"     && yum remove -y git     && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib     && yum clean all     && rm -rf /tmp/*     && mkdir -p /etc/confluent/docker /usr/logs     && useradd --no-log-init --create-home --shell /bin/bash appuser     && chown appuser:appuser -R /etc/confluent/ /usr/logs' returned a non-zero code: 1
```
3. Consulted troubleshooting steps in https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker :
4. Checked and confirmed that we are running the latest redhat ubi8-minimal base image: 8.6-941 in [dockerhub](https://hub.docker.com/r/redhat/ubi8-minimal/tags) vs 8.6-941 in the [pom.xml](https://github.com/confluentinc/common-docker/blob/master/pom.xml#L35)
5. An example is shown in the troubleshooting doc for a similar error `No match for argument: openssl-1.1.1k-5.el8_5`
6. Ran the docker base image locally, installed yum, and searched for latest openssl version
```
docker run -it redhat/ubi8-minimal:8.6-941
[root@9f713a1ac7bd /]# microdnf install yum
...
[root@9f713a1ac7bd /]# yum list --showduplicates openssl
Red Hat Universal Base Image 8 (RPMs) - BaseOS  1.3 MB/s | 803 kB     00:00
Red Hat Universal Base Image 8 (RPMs) - AppStre 4.5 MB/s | 3.0 MB     00:00
Red Hat Universal Base Image 8 (RPMs) - CodeRea  57 kB/s |  20 kB     00:00
Available Packages
openssl.x86_64                1:1.1.1k-7.el8_6                 ubi-8-baseos-rpms
```
9. Updated openssl version in the pom.xml to `1.1.1k-7.el8_6` as described above
