### PR TITLE
Update package versions for ubi8 8.6-994

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,8 @@
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>
         <ubi.tar.version>1.30-6.el8</ubi.tar.version>
-        <ubi.procps-ng.version>3.3.15-9.el8</ubi.procps-ng.version>
-        <ubi.krb5-workstation.version>1.18.2-21.el8</ubi.krb5-workstation.version>
+        <ubi.procps.version>3.3.15-9.el8</ubi.procps.version>
+        <ubi.krb5.workstation.version>1.18.2-21.el8</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,10 @@
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>
-        <ubi.tar.version>1.30-5.el8</ubi.tar.version>
-        <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-14.el8</ubi.krb5.workstation.version>
-        <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
+        <ubi.tar.version>1.30-6.el8</ubi.tar.version>
+        <ubi.procps-ng.version>3.3.15-9.el8</ubi.procps-ng.version>
+        <ubi.krb5-workstation.version>1.18.2-21.el8</ubi.krb5-workstation.version>
+        <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>


### PR DESCRIPTION
-        <ubi.tar.version>1.30-5.el8</ubi.tar.version>
-        <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-14.el8</ubi.krb5.workstation.version>
-        <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
+        <ubi.tar.version>1.30-6.el8</ubi.tar.version>
+        <ubi.procps-ng.version>3.3.15-9.el8</ubi.procps-ng.version>
+        <ubi.krb5-workstation.version>1.18.2-21.el8</ubi.krb5-workstation.version>
+        <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
