### PR TITLE
Pin the snakeyaml version to address multiple CVEs

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -40,6 +40,7 @@
         <argparse4j.version>0.7.0</argparse4j.version>
         <bcpkix.version>1.54</bcpkix.version>
         <gson.version>2.8.9</gson.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
 
         <!--Test dependencies-->


### PR DESCRIPTION
During the Q4 2022 CVE review I have realized that cp-base image keep bringing the outdated snakeyaml dependency. The first suspect jmx_exporter has been mostly addressed, this is the second place where snakeyaml is brought in as a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar This will need to be pint-merged to all previous branches.

