### PR TITLE
Pin Snakeyaml version to resolve multiple CVEs

### DIFF
--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -80,9 +80,9 @@ RUN echo "===> Updating debian ....." \
     && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 0x27BC0C8CB3D81623F59BDADCB1998361219BD9C9 \
     && echo "deb http://repos.azulsystems.com/debian stable  main" >> /etc/apt/sources.list.d/zulu.list \
     && apt-get -qq update \
-    && apt-get -y install zulu-${ZULU_OPENJDK_VERSION} \
+    && apt-get --force-yes -y install zulu-${ZULU_OPENJDK_VERSION} \
     && echo "===> Installing Kerberos Patch ..." \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y install krb5-user \
+    && DEBIAN_FRONTEND=noninteractive apt-get --force-yes -y install krb5-user \
     && rm -rf /var/lib/apt/lists/*
 
 ENV CUB_CLASSPATH=/etc/confluent/docker/docker-utils.jar

--- a/base/Dockerfile.deb8
+++ b/base/Dockerfile.deb8
@@ -60,7 +60,7 @@ RUN echo "===> Updating debian ....." \
     && apt-get -qq update \
     \
     && echo "===> Installing curl wget netcat python...." \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --force-yes -y \
                 apt-transport-https \
                 curl \
                 gnupg-curl \

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -40,6 +40,7 @@
         <argparse4j.version>0.7.0</argparse4j.version>
         <bcpkix.version>1.54</bcpkix.version>
         <gson.version>2.7</gson.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
 
     <dependencies>
@@ -79,6 +80,12 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+
         <!--Test dependencies-->
         <dependency>
             <groupId>io.confluent</groupId>
@@ -86,6 +93,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>


### PR DESCRIPTION
During the Q4 2022 CVE review I have realized that cp-base image keep bringing the outdated snakeyaml dependency. The first suspect jmx_exporter has been mostly addressed, this is the second place where snakeyaml is brought in as a transitive dependency of com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar This will need to be pint-merged to all the branches.