### PR TITLE
Pin version of snakeyaml to address multiple CVEs. 

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -40,6 +40,7 @@
         <argparse4j.version>0.7.0</argparse4j.version>
         <bcpkix.version>1.54</bcpkix.version>
         <gson.version>2.7</gson.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
 
     <dependencies>
@@ -77,6 +78,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
 
         <!--Test dependencies-->


### PR DESCRIPTION
This mirror the changes applied to versions 5.4 and 5.5. 
This is a separate pull request as changes made to 5.4. and 5.5 had a merge conflict due to debian8 dockerfile modifications. 