### PR TITLE
Bump UBI8 Base Image to latest 8.7-923.1669829893

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.7-923</ubi.image.version>
+        <ubi.image.version>8.7-1037</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.7-1037</ubi.image.version>
+        <ubi.image.version>8.7-923.1669829893</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
UBI-Minimal 8.7.923.1669829893 has a Rating index of A
![image](https://user-images.githubusercontent.com/103946139/208065138-9ac9efd3-9f4c-4cc4-9616-b470d0fc2109.png)
Whereas the older image has a Rating index of B
![image](https://user-images.githubusercontent.com/103946139/208065191-b739a3ad-4060-4b77-be2d-a268baf8ac61.png)

These ratings affect Redhat certification required for publishing CP on openshift ecosystem via CFK operator