### PR TITLE
build: update pinned dependencies

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -100,7 +100,7 @@ RUN microdnf --nodocs install yum \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
     # Work around until Redhat releases updated base image
-    && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib \
+    && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib libsolv libxml2 \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \

--- a/pom.xml
+++ b/pom.xml
@@ -32,16 +32,16 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.2.1-cp1</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.6-854</ubi.image.version>
+        <ubi.image.version>8.7-1049</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-6.el8_5</ubi.openssl.version>
+        <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
-        <ubi.netcat.version>7.70-6.el8</ubi.netcat.version>
+        <ubi.netcat.version>7.70-8.el8</ubi.netcat.version>
         <ubi.python36.version>3.6.8-38.module+el8.5.0+12207+5c5719bc</ubi.python36.version>
-        <ubi.tar.version>1.30-5.el8</ubi.tar.version>
-        <ubi.procps.version>3.3.15-6.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-14.el8</ubi.krb5.workstation.version>
-        <ubi.iputils.version>20180629-9.el8</ubi.iputils.version>
+        <ubi.tar.version>1.30-6.el8</ubi.tar.version>
+        <ubi.procps.version>3.3.15-9.el8</ubi.procps.version>
+        <ubi.krb5.workstation.version>1.18.2-22.el8_7</ubi.krb5.workstation.version>
+        <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-189.5.el8_6</ubi.glibc.version>
+        <ubi.glibc.version>2.28-211.el8</ubi.glibc.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.15-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.18-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
- pinned rpms in current ubi image are causing build failures in common-docker
- update pinned ubi image version to latest, and bump pinned package versions to versions available in that image

Signed-off-by: Gary V. Vaughan <gvaughan@confluent.io>