### PR TITLE
chore:  update base image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.7-1049</ubi.image.version>
+        <ubi.image.version>8.7-1049.1675784874</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-7.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
common-docker builds failing:
https://confluentinc.atlassian.net/browse/DP-10938

Error:
[ERROR] The command '/bin/sh -c yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1

Resolution:
Update redhat ubi base image
https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-||-%22${SKIP_SECURITY_UPDATE_CHECK}%22'-returned-a-non-zero-code:-1in-common-docker