### PR TITLE
fix catch22 and allow to install deb packages even if apt update fails

### DIFF
--- a/base/Dockerfile.deb9
+++ b/base/Dockerfile.deb9
@@ -42,8 +42,7 @@ COPY requirements.txt .
 
 ARG ZULU_JDK_VERSION="8.0.302-1"
 
-RUN apt update \
-    && apt install -y apt-transport-https bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
+RUN apt update; apt install -y apt-transport-https bash curl git wget netcat-openbsd python python-pip python-setuptools python-enum34 \
     && curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-2_all.deb \
     && dpkg --install zulu-repo_1.0.0-2_all.deb \
     && rm -f zulu-repo_1.0.0-2_all.deb \


### PR DESCRIPTION
CP 5.5.x docker image builds were failing for various reasons, some were identified in  DP-10938 but additional problems persisted. 
Debian based images failed to build because apt update command failed due to lack of the package apt-transport-https
package apt-transport-https was installed AFTER apt update succeeds. 
This change allows for installing packages even if apt update fails. 
Changing the order and first installing apt-transport-https before running apt update fails with HTTP errors 404 due to subpatch mismatch 
http://security.debian.org/debian-security/pool/updates/main/n/nghttp2/libnghttp2-14_1.18.1-1+deb9u1_amd64.deb does not exist but, 
http://security.debian.org/debian-security/pool/updates/main/n/nghttp2/libnghttp2-14_1.18.1-1+deb9u2_amd64.deb does...