### PR TITLE
add the switch to ignore zulu-openjdk repository when looking for updates

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -115,7 +115,7 @@ RUN microdnf --nodocs install yum \
 # security update is availible. We skip checks from ZuluJDK repos because Confluent pins those upstream versions for various reasons 
 # such as identified bugs in ZuluJDK's software.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/


### PR DESCRIPTION
The ubi8 dockerfile is currently missing the logic to ignore the zulu-openjdk repository when checking for updates. 
The expected behavior as described in the comments is to ignore zulu-openjdk repository as the java version is pinned. 