### PR TITLE
update openjdk to the latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <ubi.glibc.version>2.28-211.el8</ubi.glibc.version>
         <ubi.curl.version>7.61.1-25.el8_7.1</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>8.0.362-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>8.0.362-3</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>21.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>54.*</ubi.python.setuptools.version>


### PR DESCRIPTION
update the zulu openjdk to the latest version. This combined with the flawed logic of checking for updates was causing container builds to fail. 