### PR TITLE
DP-10966 Cherry pick hotfix rc fixes to downstream -post branches

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -101,7 +101,7 @@ RUN microdnf --nodocs install yum \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
     # Work around until Redhat releases updated base image
-    && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib libsolv libxml2 \
+    && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib libksba libsolv libxml2 \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \


### PR DESCRIPTION
This PR is all of the changesets that were required to successfully build common-docker for  7.2.1-cp1-rc230206224111, 7.2.2-cp1-rc230109163917 and 7.3.1-cp3-rc230208200712 hotfixes, cherry-picked back into the oldest supported -post branch 5.5.13-post in preparation for pint merge propagation downstream