### PR TITLE
upgrade ubi8-minimal to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.7-1085.1679482090</ubi.image.version>
+        <ubi.image.version>8.7-1107</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-9.el8_7</ubi.openssl.version>
         <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>


### PR DESCRIPTION
This changes the ubi8-minimal image to the latest version. 

The master build is currently failing like:
```
18:40:39  [ERROR] The command '/bin/sh -c yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```

https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/2565472764/Troubleshooting#The-command-'/bin/sh--c-yum-check-update-%7C%7C-%22$%7BSKIP_SECURITY_UPDATE_CHECK%7D%22'-returned-a-non-zero-code:-1in-common-docker says this is how to address this.