### PR TITLE
APPSEC-2550: Followup to APPSEC-2550: cleanup of dependency versions

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -38,8 +38,6 @@
         <apacheda.version>1.0.0-M33</apacheda.version>
         <apacheds.version>2.0.0-M21</apacheds.version>
         <argparse4j.version>0.7.0</argparse4j.version>
-        <bcpkix.version>1.54</bcpkix.version>
-        <gson.version>2.7</gson.version>
     </properties>
 
     <dependencies>
@@ -58,7 +56,6 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
             <scope>compile</scope>
         </dependency>
 
@@ -91,7 +88,6 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>${bcpkix.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The conflict resolution for first PR for APPSEC-2550 (https://github.com/confluentinc/common-docker/pull/293)  made me realize that we:
- bring outdated version of gson
- bring outdated version of bouncycastle
- both of the above mentioned dependencies are defined in common
This PR removes the version definitions to make utility belt use the versions defined in common. 