### PR TITLE
Bump common-docker version to 7.5.0-0

### DIFF
--- a/base-lite/pom.xml
+++ b/base-lite/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>7.4.0-0</version>
+        <version>7.5.0-0</version>
     </parent>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
### Change Description

This is to fix packaging master build failure issue https://jenkins.confluent.io/job/confluentinc/job/packaging/job/master/ - 
```
The project io.confluent:cp-base-lite:[unknown-version] (/tmp/confluent/common-docker/base-lite/pom.xml) has 1 error
09:06:09  [ERROR]     Non-resolvable parent POM for io.confluent:cp-base-lite:[unknown-version]: Could not find artifact io.confluent:common-docker:pom:7.4.0-0 in confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-packaging) and 'parent.relativePath' points at wrong local POM @ line 23, column 13 -> [Help 2]
```

