### PR TITLE
Update cp-base package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,20 +30,20 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.7-1107</ubi.image.version>
+        <ubi.image.version>8.8-860</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-9.el8_7</ubi.openssl.version>
-        <ubi.wget.version>1.19.5-10.el8</ubi.wget.version>
+        <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>
         <ubi.netcat.version>7.70-8.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.13-2.module+el8.7.0+17195+44752b34</ubi.python39.version>
-        <ubi.tar.version>1.30-6.el8_7.1</ubi.tar.version>
-        <ubi.procps.version>3.3.15-9.el8</ubi.procps.version>
+        <ubi.python39.version>3.9.16-1.module+el8.8.0+17625+b531f198</ubi.python39.version>
+        <ubi.tar.version>1.30-9.el8</ubi.tar.version>
+        <ubi.procps.version>3.3.15-13.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-22.el8_7</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-211.el8</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-25.el8_7.3</ubi.curl.version>
+        <ubi.glibc.version>2.28-225.el8</ubi.glibc.version>
+        <ubi.curl.version>7.61.1-30.el8_8.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.18-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
### Change Description
Build failure: 
```
0:46:33  [INFO] Complete!
10:46:34  [INFO] zulu-openjdk - Azul Systems Inc., Zulu packages 4.2 MB/s | 583 kB     00:00    
10:46:34  [INFO] No match for argument: wget-1.19.5-10.el8
10:46:34  [INFO] No match for argument: python39-3.9.13-2.module+el8.7.0+17195+44752b34
10:46:34  [INFO] No match for argument: tar-1.30-6.el8_7.1
10:46:34  [INFO] No match for argument: procps-ng-3.3.15-9.el8
10:46:34  [INFO] Package xz-libs-5.2.4-4.el8_6.x86_64 is already installed.
10:46:34  [INFO] Package glibc-2.28-211.el8.x86_64 is already installed.
10:46:34  [INFO] Package glibc-common-2.28-211.el8.x86_64 is already installed.
10:46:34  [INFO] Package glibc-minimal-langpack-2.28-211.el8.x86_64 is already installed.
10:46:34  [INFO] Package curl-7.61.1-25.el8_7.3.x86_64 is already installed.
10:46:34  [INFO] Package libcurl-7.61.1-25.el8_7.3.x86_64 is already installed.
10:46:34  [INFO] Error: Unable to find a match: wget-1.19.5-10.el8 python39-3.9.13-2.module+el8.7.0+17195+44752b34 tar-1.30-6.el8_7.1 procps-ng-3.3.15-9.el8
10:46:34  [INFO] 
10:46:35  [ERROR] The command '/bin/sh -c microdnf --nodocs install yum     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt     && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm     && yum --nodocs install -y --setopt=install_weak_deps=False         git         "openssl${OPENSSL_VERSION}"         "wget${WGET_VERSION}"         "nmap-ncat${NETCAT_VERSION}"         "python39${PYTHON39_VERSION}"         "python39-pip${PYTHON_PIP_VERSION}"         "tar${TAR_VERSION}"         "procps-ng${PROCPS_VERSION}"         "krb5-workstation${KRB5_WORKSTATION_VERSION}"         "iputils${IPUTILS_VERSION}"         "hostname${HOSTNAME_VERSION}"         "xz-libs${XZ_LIBS_VERSION}"         "glibc${GLIBC_VERSION}"         "glibc-common${GLIBC_VERSION}"         "glibc-minimal-langpack${GLIBC_VERSION}"         "curl${CURL_VERSION}"         "libcurl${CURL_VERSION}"         "zulu11-ca-jdk-headless${ZULU_OPENJDK_VERSION}" "zulu11-ca-jre-headless${ZULU_OPENJDK_VERSION}"     && alternatives --set python /usr/bin/python3     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}"     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}"     && yum remove -y git     && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib libksba libsolv libxml2     && yum clean all     && rm -rf /tmp/*     && mkdir -p /etc/confluent/docker /usr/logs     && useradd --no-log-init --create-home --shell /bin/bash appuser     && chown appuser:appuser -R /etc/confluent/ /usr/logs' returned a non-zero code: 1
10:46:35  [WARNING] An attempt failed, will retry 1 more times
```
Updating package versions

PR also failed with:
```
12:07:37  [INFO]  ---> Running in cc792cffa1f6
12:07:38  [INFO] Red Hat Universal Base Image 8 (RPMs) - BaseOS  1.6 MB/s | 837 kB     00:00    
12:07:39  [INFO] Red Hat Universal Base Image 8 (RPMs) - AppStre 5.4 MB/s | 3.3 MB     00:00    
12:07:40  [INFO] Red Hat Universal Base Image 8 (RPMs) - CodeRea 327 kB/s | 103 kB     00:00    
12:07:40  [INFO] 
12:07:40  [INFO] coreutils-single.x86_64          8.30-15.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] crypto-policies.noarch           20221215-1.gitece0092.el8     ubi-8-baseos-rpms
12:07:40  [INFO] curl.x86_64                      7.61.1-30.el8_8.2             ubi-8-baseos-rpms
12:07:40  [INFO] file-libs.x86_64                 5.33-24.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] glib2.x86_64                     2.56.4-161.el8                ubi-8-baseos-rpms
12:07:40  [INFO] glibc.x86_64                     2.28-225.el8                  ubi-8-baseos-rpms
12:07:40  [INFO] glibc-common.x86_64              2.28-225.el8                  ubi-8-baseos-rpms
12:07:40  [INFO] glibc-minimal-langpack.x86_64    2.28-225.el8                  ubi-8-baseos-rpms
12:07:40  [INFO] libarchive.x86_64                3.3.3-5.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] libcurl.x86_64                   7.61.1-30.el8_8.2             ubi-8-baseos-rpms
12:07:40  [INFO] libffi.x86_64                    3.1-24.el8                    ubi-8-baseos-rpms
12:07:40  [INFO] librepo.x86_64                   1.14.2-4.el8                  ubi-8-baseos-rpms
12:07:40  [INFO] librhsm.x86_64                   0.0.3-5.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] libselinux.x86_64                2.9-8.el8                     ubi-8-baseos-rpms
12:07:40  [INFO] libssh.x86_64                    0.9.6-6.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] libssh-config.noarch             0.9.6-6.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] redhat-release.x86_64            8.8-0.8.el8                   ubi-8-baseos-rpms
12:07:40  [INFO] setup.noarch                     2.12.2-9.el8                  ubi-8-baseos-rpms
12:07:41  [ERROR] The command '/bin/sh -c yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```

Updating base image version.


### Testing
Pull redhat image locally and installed packages individually with new version. 
