### PR TITLE
add license section to cp-base-lite README

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -35,3 +35,7 @@ To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies
 ```
 mvn clean package -Pdocker -DskipTests # Build local images
 ```
+
+## License
+
+Usage of this image is subject to the license terms of the software contained within. Please refer to Confluent's Docker images documentation [reference](https://docs.confluent.io/platform/current/installation/docker/image-reference.html) for further information. The software to extend and build the custom Docker images is available under the Apache 2.0 License.


### PR DESCRIPTION
### Change Description
Add license section to cp-base-lite README as part of broad initiative to clean up public docker image license text in Docker Hub and GitHub

### Testing
N/A