### PR TITLE
CPF-174: Add 'dub wait' and dub 'http-ready' functionality

### DIFF
--- a/base-lite/ub/ub_test.go
+++ b/base-lite/ub/ub_test.go
@@ -391,10 +391,6 @@ func Test_waitForServer(t *testing.T) {
 }
 
 func Test_waitForHttp(t *testing.T) {
-	//mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	//	w.WriteHeader(http.StatusOK)
-	//}))
-
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/names" {
 			w.WriteHeader(http.StatusOK)

--- a/base-lite/ub/ub_test.go
+++ b/base-lite/ub/ub_test.go
@@ -367,7 +367,7 @@ func Test_waitForServer(t *testing.T) {
 			args: args{
 				host:    "localhost",
 				port:    port + 1,
-				timeout: time.Duration(int64(5) * int64(time.Second)),
+				timeout: time.Duration(5) * time.Second,
 			},
 			want: false,
 		},
@@ -376,7 +376,7 @@ func Test_waitForServer(t *testing.T) {
 			args: args{
 				host:    "localhost",
 				port:    port,
-				timeout: time.Duration(int64(5) * int64(time.Second)),
+				timeout: time.Duration(5) * time.Second,
 			},
 			want: true,
 		},
@@ -400,10 +400,10 @@ func Test_waitForHttp(t *testing.T) {
 	}))
 	defer mockServer.Close()
 
-	url := mockServer.URL
+	serverURL := mockServer.URL
 
 	type args struct {
-		url     string
+		URL     string
 		timeout time.Duration
 	}
 	tests := []struct {
@@ -414,31 +414,31 @@ func Test_waitForHttp(t *testing.T) {
 		{
 			name: "valid server address, valid url",
 			args: args{
-				url:     url + "/names",
-				timeout: time.Duration(int64(5) * int64(time.Second)),
+				URL:     serverURL + "/names",
+				timeout: time.Duration(5) * time.Second,
 			},
 			wantErr: false,
 		},
 		{
 			name: "valid server address, invalid url",
 			args: args{
-				url:     url,
-				timeout: time.Duration(int64(5) * int64(time.Second)),
+				URL:     serverURL,
+				timeout: time.Duration(5) * time.Second,
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid server address",
 			args: args{
-				url:     "http://invalidAddress:50111/names",
-				timeout: time.Duration(int64(5) * int64(time.Second)),
+				URL:     "http://invalidAddress:50111/names",
+				timeout: time.Duration(5) * time.Second,
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := waitForHttp(tt.args.url, tt.args.timeout); (err != nil) != tt.wantErr {
+			if err := waitForHttp(tt.args.URL, tt.args.timeout); (err != nil) != tt.wantErr {
 				t.Errorf("waitForHttp() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
### Change Description
For `confluent-local` we implemented required cub/dub utilities in golang. We are now extending the golang utilities to add the remaining functionalities

In this PR we are implementing:

1.  `dub wait` utility which will wait for a service to start listening on a port
2.  `dub http-ready` utility which will wait for a HTTP/HTTPS URL to be retrievable

### Testing
Added UT and tested locally
