### PR TITLE
Revert "Fix compilation error in EmbeddedKafkaCluster (#312)"

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
@@ -352,7 +352,6 @@ public class EmbeddedKafkaCluster {
             false,
             NUM_PARTITIONS,
             DEFAULT_REPLICATION_FACTOR,
-            false,
             false
         );
 


### PR DESCRIPTION
### Change Description
This reverts commit d09c0e4bfbeb1c2d56190db16ca78150d28d4e22.

additional parameter in TestUtils#createBrokerConfig was reverted in 
ce-kafka https://github.com/confluentinc/ce-kafka/commit/4619f7e3f6590e580de26b2b4f4f37e1dd97e93f#diff-b8f9f9d1b191457cbdb332a3429f0ad65b50fa4cef5af8562abcfd1f177a2cfe
