### PR TITLE
updated packages versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.8-1014</ubi.image.version>
+        <ubi.image.version>8.8-1037</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-9.el8_7</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>
@@ -43,9 +43,9 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-225.el8</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-30.el8_8.2</ubi.curl.version>
+        <ubi.curl.version>7.61.1-30.el8_8.3</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.18-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.20-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>67.8.0</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
common-docker builds are failing because of check put in Dockerfile for cp-base-new 
`yum --disablerepo="zulu-openjdk" check-update`.
Updating packages to the latest versions so that this check passes
