### PR TITLE
Update ubi8 image version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <docker.file>Dockerfile.${docker.os_type}</docker.file>
         <docker.tag>${project.version}-${docker.os_type}</docker.tag>
         <!-- Versions-->
-        <ubi.image.version>8.8-1037</ubi.image.version>
+        <ubi.image.version>8.8-1072</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-9.el8_7</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>


### PR DESCRIPTION
### Change Description

common-docker builds https://jenkins.confluent.io/view/Docker%20Image%20Snapshot/ have started failing for the last couple of days as the new ubi8 image `8.8-1072` was published 2 days ago https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&push_date=1695150043000&container-tabs=overview 

Currently, it fails at this step 
```
Step 39/47 : RUN yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"

02:09:00  [ERROR] The command '/bin/sh -c yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```
Bumping up (using the latest) to fix the build.


### Testing
Pulled the latest registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072 image locally and verified other packages versions by installing them manually
