### PR TITLE
Fix cp-base-new docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <ubi.iputils.version>20180629-10.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-225.el8</ubi.glibc.version>
+        <ubi.glibc.version>2.28-225.el8_8.6</ubi.glibc.version>
         <ubi.curl.version>7.61.1-30.el8_8.3</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.20-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
### Change Description

common-docker builds https://jenkins.confluent.io/view/Docker%20Image%20Snapshot/ have started failing for the last couple of days
Currently, it fails at this step 
```
Step 39/47 : RUN yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"

02:09:00  [ERROR] The command '/bin/sh -c yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"' returned a non-zero code: 1
```
Bumping up glibc version to fix the build.