### PR TITLE
add package update to explicitly update packages that do not require …

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -79,7 +79,7 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluent
 RUN microdnf --nodocs install yum \
     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
     && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
-    && yup -y upgrade \
+    && yum --nodocs update -y \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
         "openssl${OPENSSL_VERSION}" \
@@ -103,8 +103,6 @@ RUN microdnf --nodocs install yum \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \
-    # Work around until Redhat releases updated base image
-    && yum --nodocs update -y tzdata libgcc libstdc++ cyrus-sasl-lib libksba libsolv libxml2 \
     && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -79,6 +79,7 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluent
 RUN microdnf --nodocs install yum \
     && rpm --import https://www.azul.com/files/0xB1998361219BD9C9.txt \
     && yum --nodocs -y install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm \
+    && yup -y upgrade \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
         "openssl${OPENSSL_VERSION}" \


### PR DESCRIPTION
### Change Description
Update the packages that do not require a specific version to allow us to pass the check in line 121:
RUN yum --disablerepo="zulu-openjdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"

This is specifically needed when there is no updated container image, but there are updated packages for the given image. 