### PR TITLE
added a new docker-arm profile to build docker containers in arm64 

### DIFF
--- a/base-lite/pom.xml
+++ b/base-lite/pom.xml
@@ -92,6 +92,28 @@
                     </buildArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.43.4</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <build>
+                                <args>
+                                    <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                                    <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}
+                                    </ZULU_OPENJDK_VERSION>
+                                    <SKIP_SECURITY_UPDATE_CHECK>
+                                        ${docker.skip-security-update-check}
+                                    </SKIP_SECURITY_UPDATE_CHECK>
+                                    <GOLANG_VERSION>${golang.version}</GOLANG_VERSION>
+                                </args>
+                            </build>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -143,6 +143,44 @@
                     </buildArgs>
                 </configuration>
             </plugin>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <version>0.43.4</version>
+            <configuration>
+              <images>
+                <image>
+                  <build>
+                    <args>
+                      <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
+                      <OPENSSL_VERSION>-${ubi.openssl.version}</OPENSSL_VERSION>
+                      <WGET_VERSION>-${ubi.wget.version}</WGET_VERSION>
+                      <NETCAT_VERSION>-${ubi.netcat.version}</NETCAT_VERSION>
+                      <PYTHON39_VERSION>-${ubi.python39.version}</PYTHON39_VERSION>
+                      <TAR_VERSION>-${ubi.tar.version}</TAR_VERSION>
+                      <PROCPS_VERSION>-${ubi.procps.version}</PROCPS_VERSION>
+                      <KRB5_WORKSTATION_VERSION>-${ubi.krb5.workstation.version}
+                      </KRB5_WORKSTATION_VERSION>
+                      <IPUTILS_VERSION>-${ubi.iputils.version}</IPUTILS_VERSION>
+                      <HOSTNAME_VERSION>-${ubi.hostname.version}</HOSTNAME_VERSION>
+                      <XZ_LIBS_VERSION>-${ubi.xzlibs.version}</XZ_LIBS_VERSION>
+                      <GLIBC_VERSION>-${ubi.glibc.version}</GLIBC_VERSION>
+                      <CURL_VERSION>-${ubi.curl.version}</CURL_VERSION>
+                      <ZULU_OPENJDK_VERSION>-${ubi.zulu.openjdk.version}</ZULU_OPENJDK_VERSION>
+                      <PYTHON_PIP_VERSION>-${ubi.python.pip.version}</PYTHON_PIP_VERSION>
+                      <PYTHON_SETUPTOOLS_VERSION>==${ubi.python.setuptools.version}
+                      </PYTHON_SETUPTOOLS_VERSION>
+                      <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
+                        ${ubi.python.confluent.docker.utils.version}
+                      </PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
+                      <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}
+                      </SKIP_SECURITY_UPDATE_CHECK>
+                    </args>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Change Description
This change adds support to build docker images on arm64 machines/laptops. This is related to following PR on common.
https://github.com/confluentinc/common/pull/563
This change requires  the above PR to be merged prior to this.

The following are the changes I have made

1. Added a new profile docker-arm that uses the [io.fabric8:docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin)
2. This plugin supports docker image building in arm64 laptops.

### Testing

1. I have tested the change by building the docker arm64 image on my Mac M2