### PR TITLE
CPBR-1032: adding snappy-java dependency

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -98,6 +98,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>


### PR DESCRIPTION
### Change Description
Adding snappy-java as dependency as it is a requirement for zookeeper 3.8.3 version

### Testing
<!-- a description of how you tested the change -->
