### PR TITLE
SVCF-4851: Fix bug where env vars with equals sign in them are ignored in confluent-local docker image

### DIFF
--- a/base-lite/ub/ub.go
+++ b/base-lite/ub/ub.go
@@ -162,12 +162,12 @@ func replaceUnderscores(s string) string {
 func ListToMap(kvList []string) map[string]string {
 	m := make(map[string]string, len(kvList))
 	for _, l := range kvList {
-		parts := strings.Split(l, "=")
-		if len(parts) == 2 {
-			m[parts[0]] = parts[1]
-		}
-	}
-	return m
+		parts := strings.SplitN(l, "=", 2)
+        	if len(parts) == 2 {
+            		m[parts[0]] = parts[1]
+        	}
+    	}
+    	return m
 }
 
 func splitToMapDefaults(separator string, defaultValues string, value string) map[string]string {

--- a/base-lite/ub/ub.go
+++ b/base-lite/ub/ub.go
@@ -163,11 +163,11 @@ func ListToMap(kvList []string) map[string]string {
 	m := make(map[string]string, len(kvList))
 	for _, l := range kvList {
 		parts := strings.SplitN(l, "=", 2)
-        	if len(parts) == 2 {
-            		m[parts[0]] = parts[1]
-        	}
-    	}
-    	return m
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+		}
+	}
+	return m
 }
 
 func splitToMapDefaults(separator string, defaultValues string, value string) map[string]string {

--- a/base-lite/ub/ub_test.go
+++ b/base-lite/ub/ub_test.go
@@ -290,8 +290,9 @@ func Test_buildProperties(t *testing.T) {
 					ExcludeWithPrefix: "KAFKA_EXCLUDE_PREFIX_",
 				},
 				environment: map[string]string{
-					"KAFKA_FOO":                       "foo",
-					"KAFKA_FOO_BAR":                   "bar",
+					"KAFKA_FOO":     "foo",
+					"KAFKA_FOO_BAR": "bar",
+					"KAFKA_LISTENER_NAME_BROKER_PLAIN_SASL_JAAS_CONFIG": `org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";`,
 					"KAFKA_IGNORED":                   "ignored",
 					"KAFKA_WITH__UNDERSCORE":          "with underscore",
 					"KAFKA_WITH__UNDERSCORE_AND_MORE": "with underscore and more",
@@ -299,12 +300,26 @@ func Test_buildProperties(t *testing.T) {
 					"KAFKA_WITH___DASH_AND_MORE":      "with dash and more",
 				},
 			},
-			want: map[string]string{"bootstrap.servers": "unknown", "default.property.key": "default.property.value", "foo": "foo", "foo.bar": "bar", "with-dash": "with dash", "with-dash.and.more": "with dash and more", "with_underscore": "with underscore", "with_underscore.and.more": "with underscore and more"},
+			want: map[string]string{
+				"bootstrap.servers":    "unknown",
+				"default.property.key": "default.property.value",
+				"foo":                  "foo",
+				"foo.bar":              "bar",
+				"listener.name.broker.plain.sasl.jaas.config": `org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";`,
+				"with-dash":                "with dash",
+				"with-dash.and.more":       "with dash and more",
+				"with_underscore":          "with underscore",
+				"with_underscore.and.more": "with underscore and more",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := buildProperties(tt.args.spec, tt.args.environment); !reflect.DeepEqual(got, tt.want) {
+			for k, v := range tt.args.environment {
+				t.Setenv(k, v)
+			}
+
+			if got := buildProperties(tt.args.spec, GetEnvironment()); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("buildProperties() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
### Change Description

So I was testing the `confluent-local` docker images and our ability to run them using SASL_PLAINTEXT instead of PLAIN. That means we would need an api key to authenticate to the local docker image.

I set all my properties correctly and ran it, but I would hit an error like:
```
java.lang.IllegalArgumentException: Could not find a 'KafkaServer' or 'controller.KafkaServer' entry in the JAAS configuration. System property 'java.security.auth.login.config' is not set
        at org.apache.kafka.common.security.JaasContext.defaultContext(JaasContext.java:150)
        at org.apache.kafka.common.security.JaasContext.load(JaasContext.java:103)
        at org.apache.kafka.common.security.JaasContext.loadServerContext(JaasContext.java:74)
        at org.apache.kafka.common.network.ChannelBuilders.create(ChannelBuilders.java:143)
        at org.apache.kafka.common.network.ChannelBuilders.serverChannelBuilder(ChannelBuilders.java:107)
```

Even if I had the right config:
``` 
KAFKA_LISTENER_NAME_CONTROLLER_PLAIN_SASL_JAAS_CONFIG='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'' \
```

I dug through the code in `ce-kafka` and did some debugging and everything looked fine to me. I looked through [KIPs](https://issues.apache.org/jira/browse/KAFKA-14369?jql=text%20~%20%22sasl.mechanism.controller.protocol%22) and various stack overflow issues, enabled trace logs and tried to see what code paths were executed... But the code path being followed in ce-kafka was as if I didn't pass in that property at all. Then I noticed when I used the following environment variable:

```
KAFKA_LISTENER_NAME_CONTROLLER_PLAIN_SASL_JAAS_CONFIG='org.apache.kafka.common.security.plain.PlainLoginModule required;' \
```
I would start to see the proper code paths be executed! If I omitted the semicolon, I would start to see validations fail. But when I had my original:
```
KAFKA_LISTENER_NAME_CONTROLLER_PLAIN_SASL_JAAS_CONFIG='org.apache.kafka.common.security.plain.PlainLoginModule required username="admin" password="admin-secret";'' \
```

No matter what I did, I could not get ce-kafka to read this. Then I realized that it was all dependent on the presence of a second equals sign! When I had a second equals sign in my config variable, everything would fail.

Then I knew that it wasn't `ce-kafka` that was failing, it was the logic inside `confluent-local` that converted environment variables to configs to pass into `ce-kafka` that had an error in it. It was most likely an error with splitting by equals.

I took a look at how `confluent-local` makes transformations and tracked it down to this code block in the launch file for the docker image:

```
ub render-properties /etc/confluent/docker/kafka-propertiesSpec.json > /etc/kafka/kafka.properties
```

Implying that the properties are rendered from a template and made into a properties file for kafka to use. If there was an error, it was going to be in that `render-properties` executable. 

I then found that `render-properties` is a CLI built in this repo. Then I looked through where the code is executed and eventually found the bug. The bug is in the `GetEnvironment()` code path. The issue is we would split a string into multiple parts by equals sign, but consider the case where we split the string into `N > 2` parts. Then the if check:

```
m := make(map[string]string, len(kvList))
...
parts := strings.Split(l, "=")
if len(parts) == 2 {
	m[parts[0]] = parts[1]
}
```

Would never trigger, meaning we would effectively lose any property in our environment variables that contained an equals sign.

This is the reason why I got errors from kafka saying it could not find the given config. 

### Testing

I adjusted our unit tests to account for this behavior. 

But an afterthought of this find - this implies nobody was ever able to use `confluent-local` in the past with anything other than plain authentication. Hopefully I'm wrong about that because if so, that's a severe limitation on what people can do with the confluent-local image. 