### PR TITLE
CONMON-824 bumping ubi8 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>6.2.15-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.9-1029</ubi.image.version>
+        <ubi.image.version>8.9-1108</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>


### PR DESCRIPTION
Increase the version tag of the ubi8 minimal image.
Change in file: `pom.xml`