### PR TITLE
DP-13727 Add CodeArtifact package paths to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -7,10 +7,18 @@ semaphore:
   enable: true
   execution_time_limit: {"hours": 1}
   pipeline_type: cp-dockerfile
-  docker_repos: ['confluentinc/cp-base-new','confluentinc/cp-base-lite','confluentinc/cp-jmxterm']
+  docker_repos: ['confluentinc/cp-base-new', 'confluentinc/cp-base-lite', 'confluentinc/cp-jmxterm']
   build_arm: true
   os_types: ["ubi8"]
   nano_version: true
   maven_skip_deploy: false
   pip_install_package: 'tox==3.28.0'
-
+code_artifact:
+  enable: true
+  package_paths:
+    - maven-snapshots/maven/io.confluent/cp-jmxterm
+    - maven-snapshots/maven/io.confluent/cp-base-lite
+    - maven-snapshots/maven/io.confluent/cp-base-new
+    - maven-snapshots/maven/io.confluent/docker-utils
+    - maven-snapshots/maven/io.confluent/utility-belt
+    - maven-snapshots/maven/io.confluent/common-docker


### PR DESCRIPTION
One of the Capsaicin requirements requires that all artifacts uploaded to CodeArtifacts come from specific Semaphore jobs.
This PR adds package_paths to service.yml so that each GitHub repo can declare the path of the CodeArtifact packages that it writes to.
For newer GitHub repos, the package_paths needs to be added to the service.yml file manually before it can write to CodeArtifact in the Semaphore pipeline.
For more information about this, see https://confluent.slack.com/archives/C038ZJ00P/p1708464192287999
