### PR TITLE
minor: set task build python version to 3.9

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -25,6 +25,7 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
+      - sem-version python 3.9
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0


### PR DESCRIPTION
### Change Description
Python test issue. The build should result the same CI build which uses python 3.9.

### Testing
<!-- a description of how you tested the change -->
