### PR TITLE
Update ubi8 image and fix curl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>6.2.15</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.9-1137</ubi.image.version>
+        <ubi.image.version>8.9-1161</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>
@@ -45,7 +45,7 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-236.el8_9.12</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-33.el8</ubi.curl.version>
+        <ubi.curl.version>7.61.1-33.el8_9.5</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.22-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
Ubi8 image update:
Build failed with:
`[INFO] Error: Unable to find a match: curl-7.61.1-33.el8 libcurl-7.61.1-33.el8`