### PR TITLE
minor: fix manifest create promotion task

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -201,7 +201,7 @@ blocks:
                   fi
                   docker tag $DOCKER_REPO:$PROMOTED_TAG $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
-  - name: Create Manifest
+  - name: Create Manifest confluentinc/cp-base-new ubi8
     dependencies: ["Promote AMD", "Promote ARM"]
     task:
       jobs:
@@ -223,6 +223,10 @@ blocks:
                   fi
                   docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
+  - name: Create Manifest confluentinc/cp-base-lite ubi8
+    dependencies: ["Promote AMD", "Promote ARM"]
+    task:
+      jobs:
         - name: Create Manifest confluentinc/cp-base-lite ubi8
           commands:
             - export OS_TYPE="ubi8"
@@ -241,6 +245,10 @@ blocks:
                   fi
                   docker manifest create $DOCKER_REPO:latest-$OS_TYPE $DOCKER_REPO:latest-$OS_TYPE$AMD_ARCH $DOCKER_REPO:latest-$OS_TYPE$ARM_ARCH
               fi
+  - name: Create Manifest confluentinc/cp-jmxterm ubi8
+    dependencies: ["Promote AMD", "Promote ARM"]
+    task:
+      jobs:
         - name: Create Manifest confluentinc/cp-jmxterm ubi8
           commands:
             - export OS_TYPE="ubi8"


### PR DESCRIPTION
### Change Description
Getting odd variance with the manifest creation step. First one results in 
```
no such manifest: docker.io/confluentinc/cp-base-new:{tag}
```
which is expected. But the subsequent errors are due to authentication 
```
errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```
Trying out completely separate blocks. 

### Testing
<!-- a description of how you tested the change -->
