### PR TITLE
CPBR-1379 | Update glibc version in common-docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-236.el8_9.12</ubi.glibc.version>
+        <ubi.glibc.version>2.28-236.el8_9.13</ubi.glibc.version>
         <ubi.curl.version>7.61.1-33.el8_9.5</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.22-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
Update glibc version in common-docker 
```
[root@8e9e07c8e71b /]# yum list --showduplicates glibc-minimal-langpack
Last metadata expiration check: 0:01:29 ago on Wed May  8 05:57:59 2024.
Installed Packages
glibc-minimal-langpack.aarch64          2.28-236.el8_9.12          @System
Available Packages
glibc-minimal-langpack.aarch64          2.28-236.el8_9.13          ubi-8-baseos-rpms
```

