### PR TITLE
CPBR-1452 | Updating ubi8 and dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,26 +33,26 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.5.3-cp1</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.9-1029</ubi.image.version>
+        <ubi.image.version>8.9-1161.1715068733</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.18-1.module+el8.9.0+20024+793d7211</ubi.python39.version>
+        <ubi.python39.version>3.9.18-3.module+el8.10.0+21142+453d2b75</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-26.el8_9</ubi.krb5.workstation.version>
+        <ubi.krb5.workstation.version>1.18.2-27.el8_10</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-236.el8.7</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-33.el8</ubi.curl.version>
+        <ubi.glibc.version>2.28-251.el8_10.2</ubi.glibc.version>
+        <ubi.curl.version>7.61.1-34.el8</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.21-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.22-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>67.8.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.64</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.78</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
         <golang.version>1.21-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager


### PR DESCRIPTION
This PR will fix the dependency issue with the hotfix of the common-docker:
`Error: Unable to find a match: python39-3.9.18-1.module+el8.9.0+20024+793d7211 krb5-workstation-1.18.2-26.el8_9 glibc-2.28-236.el8.7 glibc-common-2.28-236.el8.7 glibc-minimal-langpack-2.28-236.el8.7 curl-7.61.1-33.el8 libcurl-7.61.1-33.el8`
The PR will update ubi8 base os image and few dependency
