### PR TITLE
Update ubi8-minimal and zulu11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.0.15-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.9-1161.1715068733</ubi.image.version>
+        <ubi.image.version>8.10-896.1716497715</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>
@@ -47,7 +47,7 @@
         <ubi.glibc.version>2.28-251.el8_10.2</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.22-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.23-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>67.8.0</ubi.python.setuptools.version>


### PR DESCRIPTION
This PR will update ubi8-minimal image and zulu11 version
![image](https://github.com/confluentinc/common-docker/assets/52796221/b117d9bd-f635-4927-96e6-f78426b417d8)

