### PR TITLE
replace option with Time instance

### DIFF
--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package io.confluent.admin.utils;
-
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
@@ -355,7 +355,7 @@ public class EmbeddedKafkaCluster {
             false
         );
 
-    KafkaServer broker = TestUtils.createServer(KafkaConfig.fromProps(props), Option.empty());
+    KafkaServer broker = TestUtils.createServer(KafkaConfig.fromProps(props), Time.SYSTEM);
     brokersById.put(brokerId, broker);
   }
 


### PR DESCRIPTION
### Change Description
common-docker jar stage has been failing during utility-belt stage as option.empty() does not conform to the Time object type
we have replaced option.empty() with an instance of Time class

### Testing
https://semaphore.ci.confluent.io/workflows/5d655b96-e2b0-4e9b-877d-ff9847b5b413?pipeline_id=891c9587-464b-4efa-9c79-2723a9841ccd
