### PR TITLE
CPBR-1636 | Update ubi8-minimal base os image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-896.1717584414</ubi.image.version>
+        <ubi.image.version>8.10-1018</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-11.el8</ubi.wget.version>


### PR DESCRIPTION
This PR will bump up the [base os](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?container-tabs=gti) image for the docker images
