### PR TITLE
[RCCA-21560] remove pinned dependency

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -86,12 +86,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <version>${zookeeper.version}</version>


### PR DESCRIPTION
Bouncycastle is a transitive, test dependency of apacheds-protocol-ldap
after cleanup of common, version is no longer defined, since this is a test dependency that is not shipped with Confluent containers, we can leave it unpinned.
