### PR TITLE
CPBR-1662 Set the root logger level to ERROR for tests (#7)

### DIFF
--- a/utility-belt/src/test/resources/logback-test.xml
+++ b/utility-belt/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <!-- Console Appender using the default pattern -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- Default encoder without specifying a pattern -->
+        <encoder/>
+    </appender>
+
+    <!-- Set the root logger level to ERROR -->
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
### Change Description
common-docker maven logs are huge, occupying over 95+MB size.. semaphoreCI trims the logs and put it in workflow artifact, need to download logs every time to check issue/ troubleshooting which is not good experience.. 
it was observed that most of these are actually unit test logs, so updated the root logger level to ERROR (for unit tests)

will also raise another PR (following airlock workflow) to suppress artifacts download logs as well with `-ntp` flag
```
[INFO] Downloading from third-party-artifacts: https://confluent-524708692776.d.codeartifact.us-west-2.amazonaws.com/maven/confluent-maven/io/confluent/assembly-plugin-boilerplate/7.2.12-6/assembly-plugin-boilerplate-7.2.12-6.pom00:03
[INFO] Downloading from confluent-codeartifact-internal: https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven/io/confluent/assembly-plugin-boilerplate/7.2.12-6/assembly-plugin-boilerplate-7.2.12-6.pom
```

### Testing
PR check workflow https://semaphore.ci.confluent.io/jobs/28fb8443-fcde-4e65-848b-6b60ac4369c2 shows logs are directly visible in semaphoreCI console.
