### PR TITLE
Fix libcurl version and update ubi8 os image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.0.16-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-896.1717584414</ubi.image.version>
+        <ubi.image.version>8.10-1052</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
@@ -45,7 +45,7 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-251.el8_10.2</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-34.el8</ubi.curl.version>
+        <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.23-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <ubi.glibc.version>2.28-251.el8_10.2</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.23-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.24-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
Currently common-docker is failing due to curl version not found. This PR will fix this issue as well as update ubi8 image