### PR TITLE
CPBR-1714 | Fix glibc version issue and update ubi8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.0.16-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1052</ubi.image.version>
+        <ubi.image.version>8.10-1052.1724178568</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
@@ -44,7 +44,7 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.2</ubi.glibc.version>
+        <ubi.glibc.version>2.28-251.el8_10.4</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.24-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
Common-docker is failing for all CP version due glibc version not found. In this PR, glibc version is updated and ubi8 image is updated as well