### PR TITLE
Python version fix in the pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.19-1.module+el8.10.0+21815+bb024982</ubi.python39.version>
+        <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>


### PR DESCRIPTION
This PR will update the python version for the common-docker. Common-docker is failing due to python version