### PR TITLE
CPBR-1716: setting python version to 3.9 (#25)

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -25,6 +25,7 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
+      - sem-version python 3.9
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,6 +25,7 @@ global_job_config:
     commands:
       - checkout
       - sem-version java 8
+      - sem-version python 3.9
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0


### PR DESCRIPTION
### Change Description
This PR sets python version specifically to 3.9 as tests in common-docker are dependent on this python version. This is blocking changes required for https://confluentinc.atlassian.net/browse/CPBR-1716

### Testing
<!-- a description of how you tested the change -->
