### PR TITLE
Fix bouncycastle dependency version for common-docker jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.19-1.module+el8.10.0+21815+bb024982</ubi.python39.version>
+        <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -87,7 +87,7 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR will fix the issue with bouncycastle version against FedRAMP branch.
Reference: https://semaphore.ci.confluent.io/jobs/3c8610f9-3d08-472e-a71c-b1773c3f997a/