### PR TITLE
CPBR-1695: installing FIPS compliant openssl version 

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -84,11 +84,34 @@ gpgcheck=1 \n\
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
+# ENV required when manually installing openssl
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+# Install a FIPS-enabled version of OpenSSL. Only specific versions of OpenSSL support FIPS. Verify the supported versions at https://openssl-library.org/source/.
+# Consult the security policy document for the specific OpenSSL version to ensure proper installation in a FIPS-compliant manner.
+# Security document can also be found at https://openssl-library.org/source/ corresponding to every supported version of OpenSSL.
+# For details on the necessary configuration changes in openssl.cnf, please refer to the documentation at: https://docs.openssl.org/3.0/man7/fips_module/#description
 RUN microdnf --nodocs install yum \
-    && yum --nodocs update -y \
+    && yum --nodocs -q update -y \
+    && yum --nodocs -q install -y wget tar gzip make perl gcc \
+    && wget -q https://github.com/openssl/openssl/releases/download/openssl${OPENSSL_VERSION}/openssl${OPENSSL_VERSION}.tar.gz \
+    && tar -xzf openssl${OPENSSL_VERSION}.tar.gz \
+    && cd openssl${OPENSSL_VERSION} \
+    && echo "installing FIPS compliant openssl" \
+    && ./Configure enable-fips \
+    && make > /dev/null 2>&1 \
+    && make install > /dev/null 2>&1 \
+    && echo "successfully installed FIPS compliant openssl" \
+    && cd .. \
+    && rm -rf openssl${OPENSSL_VERSION} openssl${OPENSSL_VERSION}.tar.gz \
+    && echo "updating openssl config for FIPS" \
+    && sed -i '/# .include fipsmodule.cnf/a\.include /usr/local/ssl/fipsmodule.cnf' /usr/local/ssl/openssl.cnf \
+    && sed -i 's/^default = default_sect$/fips = fips_sect/' /usr/local/ssl/openssl.cnf \
+    && sed -i 's/\[default_sect\]/[fips_sect]/' /usr/local/ssl/openssl.cnf \
+    && sed -i '/\[fips_sect\]/a\activate = 1' /usr/local/ssl/openssl.cnf \
+    && yum remove -y wget tar make perl gcc glibc-gconv-extra --setopt=clean_requirements_on_remove=1 \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
-        "openssl${OPENSSL_VERSION}" \
         "wget${WGET_VERSION}" \
         "nmap-ncat${NETCAT_VERSION}" \
         "python39${PYTHON39_VERSION}" \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -123,7 +123,7 @@
                 <configuration>
                     <buildArgs>
                         <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
-                        <OPENSSL_VERSION>-${ubi.openssl.version}</OPENSSL_VERSION>
+                        <OPENSSL_VERSION>-${fips.openssl.version}</OPENSSL_VERSION>
                         <WGET_VERSION>-${ubi.wget.version}</WGET_VERSION>
                         <NETCAT_VERSION>-${ubi.netcat.version}</NETCAT_VERSION>
                         <PYTHON39_VERSION>-${ubi.python39.version}</PYTHON39_VERSION>
@@ -153,7 +153,7 @@
                   <build>
                     <args>
                       <UBI_MINIMAL_VERSION>${ubi.image.version}</UBI_MINIMAL_VERSION>
-                      <OPENSSL_VERSION>-${ubi.openssl.version}</OPENSSL_VERSION>
+                      <OPENSSL_VERSION>-${fips.openssl.version}</OPENSSL_VERSION>
                       <WGET_VERSION>-${ubi.wget.version}</WGET_VERSION>
                       <NETCAT_VERSION>-${ubi.netcat.version}</NETCAT_VERSION>
                       <PYTHON39_VERSION>-${ubi.python39.version}</PYTHON39_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <io.confluent.common-docker.version>7.8.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi.image.version>8.10-1086</ubi.image.version>
+        <!-- OpenSSL version that is FIPS compliant -->
+        <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>


### PR DESCRIPTION
### Change Description
This PR installs FIPS enabled openssl in cp base new docker images.

### Testing
Following simple test was run to make sure FIPS is enabled for openssl. openssl is failing for md5 and passing for SHA256

```
[root@d88f07127ba0 ~]# openssl md5 anaconda-post.log
Error setting digest
C0C6068FFFFF0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (MD5 : 102), Properties ()
C0C6068FFFFF0000:error:03000086:digital envelope routines:evp_md_init_internal:initialization error:crypto/evp/digest.c:254:
```

```
[root@d88f07127ba0 ~]# openssl sha256 anaconda-post.log
SHA2-256(anaconda-post.log)= 7249a74ddc50e4ee5a5107fb4063a35aa534ed8b82975b7fe0d2bc7b69c9e8de
```