### PR TITLE
Update confluent.docker.utils.version to latest version i.e. v0.0.85

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.82</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.85</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
### Change Description
This PR updates the latest version of confluent-docker-utils - v0.0.85 for [cp-base-new](https://confluentinc.atlassian.net/browse/CP-base-new) in 7.0.x, and will be pint merged to master.
### Testing
<!-- a description of how you tested the change -->
