### PR TITLE
CPBR-1695: setting LD_LIBRARY_PATH correctly for both amd and arm images

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -84,8 +84,10 @@ gpgcheck=1 \n\
 gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
-# ENV required when manually installing openssl
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+# ENV required when manually installing openssl,
+# for arm64 required binaries are present in /usr/local/lib
+# for amd64 required binaries are present in /usr/local/lib64, hence setting LD_LIBRARY_PATH accordingly
+ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH
 
 # Install a FIPS-enabled version of OpenSSL. Only specific versions of OpenSSL support FIPS. Verify the supported versions at https://openssl-library.org/source/.
 # Consult the security policy document for the specific OpenSSL version to ensure proper installation in a FIPS-compliant manner.


### PR DESCRIPTION
### Change Description
This PR updates env variable LD_LIBRARY_PATH to /usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH
Previously it was set to /usr/local/lib:$LD_LIBRARY_PATH. This was working correctly for arm64 based machines as the libssl.so.3 file is present in /usr/local/lib directory. But for amd64 image, this file is present in /usr/local/lib64 directory.

### Testing
<!-- a description of how you tested the change -->
