### PR TITLE
upgrade ubi.openssl.version to 1:1.1.1k-14.el8_6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <!-- Versions-->
         <ubi.image.version>8.10-1086</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
+        <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
         <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>


### PR DESCRIPTION
### Change Description
upgrade ubi.openssl.version to 1:1.1.1k-14.el8_6

### Testing
<!-- a description of how you tested the change -->
