### PR TITLE
update confluent.docker.utils.version to v0.0.96

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.82
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.96

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.85</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.96</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
### Change Description
This PR updates confluent.docker.utils.version to v0.0.96
For Patch release, one of the Pre-Rc checklist steps is to update the confluent-docker-utils [tag](https://github.com/confluentinc/confluent-docker-utils/tags) to the latest in the common-docker repo [pom.xml](https://github.com/confluentinc/common-docker/blob/master/pom.xml) and [requirements.txt](https://github.com/confluentinc/common-docker/blob/master/base/requirements.txt#L1) .
The latest version currently is [v0.0.96](https://github.com/confluentinc/confluent-docker-utils/releases/tag/v0.0.96) , hence this change is being made. 
This will be pint merged from 7.1.x to master (7.0.x is not used as support for the same has ended).
### Testing
PR checks