### PR TITLE
upgrade zulu11-ca-jdk-headless version to 11.0.25-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.24-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.25-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
This PR upgrades zulu11-ca-jdk-headless version to 11.0.25-1 . This change will be made from 7.1.x to 7.6.x as only they use zulu jdk11.
### Testing
PR checks
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/375ed347-2d2e-4503-bd33-931e38b50403">
