### PR TITLE
upgrade zulu17-ca-jdk-headless version to 17.0.13-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>17.0.12-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>17.0.13-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
This PR upgrade zulu17-ca-jdk-headless version to 17.0.13-1 . This change will be made for 7.7.x as only it uses zulu jdk17.


### Testing
PR checks

<img width="932" alt="image" src="https://github.com/user-attachments/assets/aa363ea8-3dfb-45e5-aee0-ef89923a2693">
