### PR TITLE
Update python39 version to fix common-docker build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>
+        <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>


### PR DESCRIPTION
This PR will update python39 version to fix common-docker build. (cherry picked from commit 77278868d0c01b09077b1dbc16e6399eab427138)
New version of python was available yesterday just after the RC cut.  We have a check to enable only the latest packages. This is causing the common-docker pipeline to fail for CP 7.8.0

