### PR TITLE
Updating java, python and confluent-docker-utils for 7.7.0-cp4 release

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.71
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.101

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>
+        <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>
@@ -52,11 +52,11 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>17.0.12-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>17.0.13-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.85</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.101</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
         <golang.version>1.21-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager


### PR DESCRIPTION
### Change Description
This PR updates versions for java, python and confluent-docker-utils for 7.7.0-cp4 release

<img width="1009" alt="image" src="https://github.com/user-attachments/assets/39924efb-5b7f-4054-93ea-aa369aed3673">
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/36d434a4-dc76-4fb4-a0de-9a805392f5ed">
[confluent-docker-utils ](https://github.com/confluentinc/confluent-docker-utils/tree/v0.0.101)

### Testing
PR checks.
