### PR TITLE
update krb5-workstation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>
+        <ubi.krb5.workstation.version>1.18.2-30.el8_10</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
common-docker builds failed on 7.8.x and above due to krb5-workstation not being latest version
### Testing
<!-- a description of how you tested the change -->
