### PR TITLE
Updating redhat minimal, krb5 workstation version for 7.7.0-cp5 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1086</ubi.image.version>
+        <ubi.image.version>8.10-1130</ubi.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
@@ -43,7 +43,7 @@
         <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>
+        <ubi.krb5.workstation.version>1.18.2-30.el8_10</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>


### PR DESCRIPTION


### Change Description
This PR updates versions for redhat minimal, krb5 workstation for 7.7.0-cp5 release. Java version needs no update. Confluent-docker-utils version will be modified as part of another PR.
<img width="701" alt="image" src="https://github.com/user-attachments/assets/de5f9e56-13c7-4494-bbf9-a4bff8adb3c4">
<img width="982" alt="image" src="https://github.com/user-attachments/assets/d856fbdf-a3dc-4c42-8008-1f95ffb94601">
<img width="982" alt="image" src="https://github.com/user-attachments/assets/51f76f1f-9d91-466a-a621-32cc8dfaf8f0">

### Testing
PR checks
