### PR TITLE
update repo by servicebot

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version java 8
+      - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
       - sem-version python 3.9
       - . vault-setup
       - . cache-maven restore

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -24,7 +24,7 @@ global_job_config:
   prologue:
     commands:
       - checkout
-      - sem-version java 8
+      - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
       - sem-version python 3.9
       - . vault-setup
       - . cache-maven restore


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
As part of CP 8.0, java 17 is going to be used to build CP packages. More details mentioned in [Upgrade the CP Build System Softwares for CP 8.0.0](https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3740402150/Upgrade+the+CP+Build+System+Softwares+for+CP+8.0.0)
Update docker build template to use Java 17 and get the changes merged in master branches for all CP docker image repos.
### Testing
<!-- a description of how you tested the change -->
