### PR TITLE
updating confluent-docker-utils version for 7.7.0-cp5

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.101
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.121

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.101</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.121</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
         <golang.version>1.21-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager


### PR DESCRIPTION
### Change Description
We are updating confluent-docker-utils version for 7.7.0-cp5 to the currently latest available tag which is v0.0.121.
<img width="324" alt="Screenshot 2024-11-27 at 10 06 33 AM" src="https://github.com/user-attachments/assets/1cdab64b-2784-47ee-8062-9ce14d0a1aea">


### Testing
PR checks.