### PR TITLE
update ubi8 minimal image to latest version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.1.15-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1086</ubi.image.version>
+        <ubi.image.version>8.10-1130</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>


### PR DESCRIPTION
### Change Description
Update ubi8 minimal image to 8.10-1130 which is the [current latest version](https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&image=6722ca74023a282abf2b7f50)
### Testing
PR checks