### PR TITLE
Update versions in pom.xml for 7.7.1-cp1-rc241210230925

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.82
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.126

--- a/pom.xml
+++ b/pom.xml
@@ -33,30 +33,30 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.1-cp1</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1052.1724178568</ubi.image.version>
+        <ubi.image.version>8.10-1130</ubi.image.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1.1.1k-12.el8_9</ubi.openssl.version>
+        <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
-        <ubi.python39.version>3.9.19-7.module+el8.10.0+22237+51382d7a</ubi.python39.version>
+        <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
         <ubi.tar.version>1.30-9.el8</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
-        <ubi.krb5.workstation.version>1.18.2-29.el8_10</ubi.krb5.workstation.version>
+        <ubi.krb5.workstation.version>1.18.2-30.el8_10</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.4</ubi.glibc.version>
+        <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>17.0.12-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>17.0.13-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.82</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.126</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
-        <golang.version>1.21-bullseye</golang.version>
+        <golang.version>1.22.7-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
(cherry picked from commit 0f667004d33efef27fd63ca4f177a5fa70eeb9ed)

###Change Description
Since 7.7.1-cp1-rc241210230925 is created from 7.7.1-post, quite a few versions of packages have been outdated. This is causing docker images build failing with error:

`[INFO] Error: Unable to find a match: openssl-1.1.1k-12.el8_9 python39-3.9.19-7.module+el8.10.0+22237+51382d7a krb5-workstation-1.18.2-29.el8_10 glibc-2.28-251.el8_10.4 glibc-common-2.28-251.el8_10.4 glibc-minimal-langpack-2.28-251.el8_10.4
`
Hence, we are updated the versions as per the latest ones used in 7.7.x branch. Also confluent-docker-utils version is taken as the latest available tag.
