### PR TITLE
Bump ubi8 minimal image version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.1.16-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1130</ubi.image.version>
+        <ubi.image.version>8.10-1154</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>


### PR DESCRIPTION
### Change Description
Updating ubi8-minimal docker image version to latest one https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8?architecture=amd64&image=6758326b3b0f1c495c361dcb 

### Testing
Docker build in PR checks have passed
