### PR TITLE
Updating ubi8 image and jdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.8.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1130</ubi.image.version>
+        <ubi.image.version>8.10-1154</ubi.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
@@ -52,7 +52,7 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.temurin.jdk.version>17.0.12.0.0.7-2</ubi.temurin.jdk.version>
+        <ubi.temurin.jdk.version>17.0.13.0.0.11-2</ubi.temurin.jdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
This PR will update the base os image in the CP-7.8.1 and also update the termurin jdk version
