### PR TITLE
CPBR 1974: Update JDK to 21 in common-docker master branch

### DIFF
--- a/base-lite/Dockerfile.ubi8
+++ b/base-lite/Dockerfile.ubi8
@@ -68,7 +68,7 @@ RUN microdnf --nodocs install yum \
     && yum --nodocs update -y \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
         "curl${CURL_VERSION}" \
-        "temurin-17-jre${TEMURIN_JDK_VERSION}" \
+        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
     && microdnf clean all \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -126,7 +126,7 @@ RUN microdnf --nodocs install yum \
         "libcurl${CURL_VERSION}" \
         "findutils${FINDUTILS_VERSION}" \
         "crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION}" \
-        "temurin-17-jdk${TEMURIN_JDK_VERSION}" "temurin-17-jre${TEMURIN_JDK_VERSION}" \
+        "temurin-21-jdk${TEMURIN_JDK_VERSION}" \
     && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
+        <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
+        <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.temurin.jdk.version>17.0.13.0.0.11-2</ubi.temurin.jdk.version>
+        <ubi.temurin.jdk.version>21.0.6.0.0.7-1</ubi.temurin.jdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
As part of CP 8.0, java 21 is going to be used in CP docker images. This PR updates jdk17 to use jdk21 in master branch of common-docker.

### Testing
PR checks.
