### PR TITLE
Fix glibc version in the nightly branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
+        <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.25-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
+        <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.25-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
This PR will fix the version not found error for the glibc package in common-docker
Failed common-docker job: https://semaphore.ci.confluent.io/jobs/2a4c8841-c3e9-49f0-af7b-b31ad73a59c7#L2368