### PR TITLE
Fix glibc version in the CP-7.8.1 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
         <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
+        <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
+        <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>


### PR DESCRIPTION
This PR will fix the version not found error for the glibc package in common-docker
Failed common-docker job: https://semaphore.ci.confluent.io/jobs/2a4c8841-c3e9-49f0-af7b-b31ad73a59c7#L2368
(cherry picked from commit b3518ef2a448ed59f217c77dde49465afa016845)
