### PR TITLE
Adding jars required in downstream and fixing ub and package_dedupe utility path in cp-base-java

### DIFF
--- a/base-java/Dockerfile.ubi8
+++ b/base-java/Dockerfile.ubi8
@@ -7,12 +7,15 @@ ARG UBI_MINIMAL_VERSION
 
 FROM docker.io/golang:${GOLANG_VERSION} AS build-ub-package-dedupe
 RUN useradd --no-log-init --create-home --shell /bin/bash appuser
+
 WORKDIR /build/package_dedupe
 COPY --chown=appuser:appuser package_dedupe/ ./
 RUN go build -ldflags="-w -s" ./package_dedupe.go
+
 WORKDIR /build/ub
 COPY --chown=appuser:appuser ub/ ./
 RUN go build -ldflags="-w -s" ./ub.go
+
 USER appuser
 RUN go test ./...
 
@@ -54,12 +57,12 @@ RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \
     && microdnf clean all \
     && useradd --no-log-init --create-home --shell /bin/bash appuser
 
-COPY --from=build-ub-package-dedupe /build/package_dedupe /usr/bin/package_dedupe
-COPY --from=build-ub-package-dedupe /build/ub /usr/bin/ub
+COPY --from=build-ub-package-dedupe /build/package_dedupe/package_dedupe /usr/bin/package_dedupe
+COPY --from=build-ub-package-dedupe /build/ub/ub /usr/bin/ub
 
 
-COPY target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
-COPY target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
+COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 COPY --chown=appuser:appuser include/etc/cp-base-java /etc/cp-base-java
 

--- a/base-java/Dockerfile.ubi8
+++ b/base-java/Dockerfile.ubi8
@@ -66,6 +66,8 @@ COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/sh
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 COPY --chown=appuser:appuser include/etc/cp-base-java /etc/cp-base-java
 
+# Some components have hardcoded paths to /usr/share/java/cp-base-new, so to keep backward compatibility a symlink is created
+RUN ln -s /usr/share/java/${ARTIFACT_ID} /usr/share/java/cp-base-new
 
 USER appuser
 WORKDIR /home/appuser

--- a/base-java/package_dedupe/package_dedupe.go
+++ b/base-java/package_dedupe/package_dedupe.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 )
 
-func dedupe_packages(rootPath string) {
+func dedupePackages(rootPath string) {
 	sha2path := make(map[string]string)
 	err := filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -63,6 +63,11 @@ func main() {
 		fmt.Println("Usage: dedupe_packages <directory_name>")
 		os.Exit(1)
 	}
+	if os.Args[1] == "-h" || os.Args[1] == "--help" {
+		fmt.Println("Replaces multiple occurrences of a file with symlinks to the first instance of the file.\n" +
+			"Usage: dedupe_packages <directory_name>")
+		return
+	}
 	basePath := os.Args[1]
-	dedupe_packages(basePath)
+	dedupePackages(basePath)
 }

--- a/base-java/package_dedupe/package_dedupe.go
+++ b/base-java/package_dedupe/package_dedupe.go
@@ -65,7 +65,7 @@ func main() {
 	}
 	if os.Args[1] == "-h" || os.Args[1] == "--help" {
 		fmt.Println("Replaces multiple occurrences of a file with symlinks to the first instance of the file.\n" +
-			"Usage: dedupe_packages <directory_name>")
+			"Usage: package_dedupe <directory_name>")
 		return
 	}
 	basePath := os.Args[1]

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -51,6 +51,41 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Operator dependencies for metrics integration -->
+        <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-jvm</artifactId>
+            <version>${jolokia-jvm.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus.jmx</groupId>
+            <artifactId>jmx_prometheus_javaagent</artifactId>
+            <version>${jmx_prometheus_javaagent.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>disk-usage-agent</artifactId>
+            <version>${io.confluent.common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>logredactor</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/base-java/test/test_base_java_image.py
+++ b/base-java/test/test_base_java_image.py
@@ -3,7 +3,6 @@ import unittest
 
 import confluent.docker_utils as utils
 
-
 class BaseJavaImageTest(unittest.TestCase):
 
     def setUp(self):
@@ -16,13 +15,19 @@ class BaseJavaImageTest(unittest.TestCase):
         self.assertTrue(utils.path_exists_in_image(self.image, "/usr/bin/ub"))
 
     def test_ub_runnable(self):
-        ub_cmd = "bash -c '/usr/bin/ub/ub -h'"
+        ub_cmd = "bash -c 'ub -h'"
         self.assertTrue(b"utility commands" in utils.run_docker_command(image=self.image, command=ub_cmd))
+
+    def test_package_dedupe_exits(self):
+        self.assertTrue(utils.path_exists_in_image(self.image, "/usr/bin/package_dedupe"))
+
+    def test_package_dedupe_runnable(self):
+        package_dedupe_cmd = "bash -c 'package_dedupe -h'"
+        self.assertTrue(b"dedupe" in utils.run_docker_command(image=self.image, command=package_dedupe_cmd))
 
     def test_kafka_ready_jar(self):
         java_cmd = "bash -c 'java -cp \"/usr/share/java/cp-base-java/*\" io.confluent.admin.utils.cli.KafkaReadyCommand -h'"
         self.assertTrue(b"Check if Kafka is ready" in utils.run_docker_command(image=self.image, command=java_cmd))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/base-java/test/test_base_java_image.py
+++ b/base-java/test/test_base_java_image.py
@@ -23,7 +23,7 @@ class BaseJavaImageTest(unittest.TestCase):
 
     def test_package_dedupe_runnable(self):
         package_dedupe_cmd = "bash -c 'package_dedupe -h'"
-        self.assertTrue(b"dedupe" in utils.run_docker_command(image=self.image, command=package_dedupe_cmd))
+        self.assertTrue(b"package_dedupe" in utils.run_docker_command(image=self.image, command=package_dedupe_cmd))
 
     def test_kafka_ready_jar(self):
         java_cmd = "bash -c 'java -cp \"/usr/share/java/cp-base-java/*\" io.confluent.admin.utils.cli.KafkaReadyCommand -h'"


### PR DESCRIPTION
### Change Description
This PR 
1. adds all the jar dependencies that are used in downstream components but are not required for cp-base-java image builds.
2. the user group for the jars copied in the Docker Image for cp-base-java.
2. copies the actual binary instead of the directory for ub and package_dedupe in /usr/bin
3. adds some newlines to better club related commands in Dockerfile.
4. adds test for package_dedupe utility also

JIRA: https://confluentinc.atlassian.net/browse/CPBR-2258

### Testing
<!-- a description of how you tested the change -->
