### PR TITLE
CPBR-2259 | Update common-docker and java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.1.16-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1154</ubi.image.version>
+        <ubi.image.version>8.10-1179</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
@@ -47,7 +47,7 @@
         <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.25-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.26-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
This PR will update the base os image and jdk version in the CP-7.1.x for patch release