### PR TITLE
Fixing merge conflicts while updating base os

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.3-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1154</ubi.image.version>
+        <ubi.image.version>8.10-1179</ubi.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
@@ -50,7 +50,7 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>17.0.13-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>17.0.14-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
This PR will fix merge conflicts after updating base os and zulu jdk. Since zulu17 is used in 7.7.x that's why merge conflicts are there
