### PR TITLE
Fixing merge conflicts after updating base os and jdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,9 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.8.1-0</io.confluent.common-docker.version>
         <!-- Versions-->
-<<<<<<< HEAD
-        <ubi.image.version>8.10-1154</ubi.image.version>
+        <ubi.image.version>8.10-1179</ubi.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
-=======
-        <ubi.image.version>8.10-1179</ubi.image.version>
->>>>>>> origin/7.7.x
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>


### PR DESCRIPTION
This PR will fix merge conflicts after updating base os and jdk. Since zulu17 is used in 7.7.x tand 7.8.x have termurin.