### PR TITLE
CPBR-2264 | Fix glibc version in the CP-7.8.1 RC branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.5</ubi.glibc.version>
-        <ubi.curl.version>7.61.1-34.el8_10.2</ubi.curl.version>
+        <ubi.glibc.version>2.28-251.el8_10.11</ubi.glibc.version>
+        <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->


### PR DESCRIPTION
This PR will fix the glibc and curl version. This fix was there in the RC branch of common-docker but not in the RC tag. That's why its not there in the post branch. However its required in Ironbank release to have a proper build of common-docker
(cherry picked from commit b3518ef2a448ed59f217c77dde49465afa016845)
(cherry picked from commit d2ba7aa987d64806eb92497b0215eb009076b469)

