### PR TITLE
CPBR-2285 add ubi9 micro version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <io.confluent.common-docker.version>7.9.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi.image.version>8.10-1179</ubi.image.version>
+        <ubi9.image.version>9.5-1739467664</ubi9.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <io.confluent.common-docker.version>7.9.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi.image.version>8.10-1179</ubi.image.version>
-        <ubi9.image.version>9.5-1739467664</ubi9.image.version>
+        <ubi9.micro.image.version>9.5-1739467664</ubi9.micro.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
added a property to control ubi9-micro version used 
This will be initially consumed by c3++ team for onboarding their docker images
Using this PR, we can control ubi9-micro version being used by downstream components from a single place
### Testing
<!-- a description of how you tested the change -->
