### PR TITLE
CPBR-2326: adding envToProps method from dub to ub

### DIFF
--- a/base-java/ub/testResources/sampleLog4j.template
+++ b/base-java/ub/testResources/sampleLog4j.template
@@ -9,3 +9,8 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 {{ range $k, $v := splitToMapDefaults ","  $loggerDefaults $loggers}}
 log4j.logger.{{ $k }}={{ $v -}}
 {{ end }}
+
+{{- $kr_props := envToProps "LOG4J_" "" nil -}}
+{{ range $k, $v := $kr_props }}
+{{ $k }}={{ $v }}
+{{ end }}

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -137,6 +137,7 @@ func renderTemplate(templateFilePath string) error {
 	funcs := template.FuncMap{
 		"getEnv":             getEnvOrDefault,
 		"splitToMapDefaults": splitToMapDefaults,
+		"envToProps":         envToProps,
 	}
 	t, err := template.New(pt.Base(templateFilePath)).Funcs(funcs).ParseFiles(templateFilePath)
 	if err != nil {
@@ -230,6 +231,22 @@ func buildProperties(spec ConfigSpec, environment map[string]string) map[string]
 					}
 				}
 			}
+		}
+	}
+	return config
+}
+
+func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string) map[string]string {
+	env := GetEnvironment()
+	config := make(map[string]string)
+	for envName, envValue := range env {
+		if slices.Contains(excludeEnvs, envName) {
+			continue
+		}
+		if strings.HasPrefix(envName, envPrefix) {
+			trimmedEnvName := strings.TrimPrefix(envName, envPrefix)
+			propertyName := propertyNamePrefix + ConvertKey(trimmedEnvName)
+			config[propertyName] = envValue
 		}
 	}
 	return config

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -532,13 +532,16 @@ func TestEnvToProps(t *testing.T) {
 			for k, v := range tt.envVars {
 				os.Setenv(k, v)
 			}
+			defer func() {
+				for k, _ := range tt.envVars {
+					os.Unsetenv(k)
+				}
+			}()
 			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("envToProps() = %v, want %v", result, tt.expected)
 			}
-			for k, _ := range tt.envVars {
-				os.Unsetenv(k)
-			}
+
 		})
 	}
 }

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -459,3 +459,86 @@ func Test_waitForHttp(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvToProps(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVars    map[string]string
+		envPrefix  string
+		propPrefix string
+		exclude    []string
+		expected   map[string]string
+	}{
+		{
+			name: "Basic conversion with prefix",
+			envVars: map[string]string{
+				"APP_FOO_BAR": "value1",
+				"APP_BAZ":     "value2",
+				"OTHER_VAR":   "ignored",
+			},
+			envPrefix:  "APP_",
+			propPrefix: "app.",
+			exclude:    []string{},
+			expected: map[string]string{
+				"app.foo.bar": "value1",
+				"app.baz":     "value2",
+			},
+		},
+		{
+			name: "With exclusions",
+			envVars: map[string]string{
+				"APP_FOO_BAR": "value1",
+				"APP_SECRET":  "hidden",
+				"APP_BAZ":     "value2",
+			},
+			envPrefix:  "APP_",
+			propPrefix: "app.",
+			exclude:    []string{"APP_SECRET"},
+			expected: map[string]string{
+				"app.foo.bar": "value1",
+				"app.baz":     "value2",
+			},
+		},
+		{
+			name: "With special underscore conversions",
+			envVars: map[string]string{
+				"APP_SINGLE_UNDERSCORE":   "dot",
+				"APP_DOUBLE__UNDERSCORE":  "single_underscore",
+				"APP_TRIPLE___UNDERSCORE": "dash",
+			},
+			envPrefix:  "APP_",
+			propPrefix: "app.meta.",
+			exclude:    []string{},
+			expected: map[string]string{
+				"app.meta.single.underscore": "dot",
+				"app.meta.double_underscore": "single_underscore",
+				"app.meta.triple-underscore": "dash",
+			},
+		},
+		{
+			name: "Empty result",
+			envVars: map[string]string{
+				"OTHER_VAR": "ignored",
+			},
+			envPrefix:  "APP_",
+			propPrefix: "app.",
+			exclude:    []string{},
+			expected:   map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				os.Setenv(k, v)
+			}
+			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("envToProps() = %v, want %v", result, tt.expected)
+			}
+			for k, _ := range tt.envVars {
+				os.Unsetenv(k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Change Description
This PR adds [env_to_props](https://github.com/confluentinc/confluent-docker-utils/blob/e1564f5f2702e23bee12f967de067c2e950676fb/confluent/docker_utils/dub.py#L50) method in confluent-docker-utils `dub` utility to ub.go. This is required in many template files created for CP docker images.

### Testing
Unit test are added for the new method.
