### PR TITLE
Update latest ubi8 minimal base os, krb5-workstation and glibc versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi8.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.1.16-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1179</ubi8.image.version>
+        <ubi8.image.version>8.10-1179.1741795396</ubi8.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi8.wget.version>1.19.5-12.el8_10</ubi8.wget.version>
@@ -40,11 +40,11 @@
         <ubi8.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi8.python39.version>
         <ubi8.tar.version>1.30-9.el8</ubi8.tar.version>
         <ubi8.procps.version>3.3.15-14.el8</ubi8.procps.version>
-        <ubi8.krb5.workstation.version>1.18.2-30.el8_10</ubi8.krb5.workstation.version>
+        <ubi8.krb5.workstation.version>1.18.2-31.el8_10</ubi8.krb5.workstation.version>
         <ubi8.iputils.version>20180629-11.el8</ubi8.iputils.version>
         <ubi8.hostname.version>3.20-6.el8</ubi8.hostname.version>
         <ubi8.xzlibs.version>5.2.4-4.el8_6</ubi8.xzlibs.version>
-        <ubi8.glibc.version>2.28-251.el8_10.13</ubi8.glibc.version>
+        <ubi8.glibc.version>2.28-251.el8_10.14</ubi8.glibc.version>
         <ubi8.curl.version>7.61.1-34.el8_10.3</ubi8.curl.version>
         <!-- ZULU OpenJDK Package Version -->
         <ubi.zulu.openjdk.version>11.0.26-1</ubi.zulu.openjdk.version>


### PR DESCRIPTION
### Change Description
common-docker builds were failing with the errors:
`[INFO] Error: Unable to find a match: krb5-workstation-1.18.2-30.el8_10 glibc-2.28-251.el8_10.13 glibc-common-2.28-251.el8_10.13 glibc-minimal-langpack-2.28-251.el8_10.13`

This PR updates the latest ubi8 minimal base os, krb5-workstation and glibc versions.

ubi8 minimal base os version: 8.10-1179 -> 8.10-1179.1741795396
krb5-workstation version: 1.18.2-30.el8_10 -> 1.18.2-31.el8_10
glibc version: 2.28-251.el8_10.13 -> 2.28-251.el8_10.14

This version update will resolve the above failures.

### Testing
PR gating checks have run successfully