### PR TITLE
Fix merge conflicts for update latest ubi8 minimal base os, krb5-workstation and glibc versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi8.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.8.2-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1179</ubi8.image.version>
+        <ubi8.image.version>8.10-1179.1741795396</ubi8.image.version>
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
@@ -42,11 +42,11 @@
         <ubi8.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi8.python39.version>
         <ubi8.tar.version>1.30-9.el8</ubi8.tar.version>
         <ubi8.procps.version>3.3.15-14.el8</ubi8.procps.version>
-        <ubi8.krb5.workstation.version>1.18.2-30.el8_10</ubi8.krb5.workstation.version>
+        <ubi8.krb5.workstation.version>1.18.2-31.el8_10</ubi8.krb5.workstation.version>
         <ubi8.iputils.version>20180629-11.el8</ubi8.iputils.version>
         <ubi8.hostname.version>3.20-6.el8</ubi8.hostname.version>
         <ubi8.xzlibs.version>5.2.4-4.el8_6</ubi8.xzlibs.version>
-        <ubi8.glibc.version>2.28-251.el8_10.13</ubi8.glibc.version>
+        <ubi8.glibc.version>2.28-251.el8_10.14</ubi8.glibc.version>
         <ubi8.curl.version>7.61.1-34.el8_10.3</ubi8.curl.version>
         <ubi8.findutils.version>1:4.6.0-21.el8</ubi8.findutils.version>
         <ubi8.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi8.crypto.policies.scripts.version>


### PR DESCRIPTION
### Change Description
common-docker builds were failing with the errors:
`[INFO] Error: Unable to find a match: krb5-workstation-1.18.2-30.el8_10 glibc-2.28-251.el8_10.13 glibc-common-2.28-251.el8_10.13 glibc-minimal-langpack-2.28-251.el8_10.13`

This PR updates the latest ubi8 minimal base os, krb5-workstation and glibc versions.

ubi8 minimal base os version: 8.10-1179 -> 8.10-1179.1741795396
krb5-workstation version: 1.18.2-30.el8_10 -> 1.18.2-31.el8_10
glibc version: 2.28-251.el8_10.13 -> 2.28-251.el8_10.14

This version update will resolve the above failures. This PR is raised for 7.8.x again as there was a merge conflict from 7.7.x to 7.8.x (https://github.com/confluentinc/common-docker/pull/689).

### Testing
PR gating checks have run successfully
