### PR TITLE
CPBR-2326: Install hostname package and fix ub classpath in cp-base-java docker image

### DIFF
--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -56,6 +56,7 @@ RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \
     && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
     && microdnf install -y crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
     && microdnf install -y findutils${FINDUTILS_VERSION} \
+    && microdnf install -y hostname${HOSTNAME_VERSION} \
     && microdnf clean all \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && mkdir -p /etc/confluent/docker /usr/logs \

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -125,6 +125,9 @@
                         <TEMURIN_JDK_VERSION>-${ubi.temurin.jdk.version}</TEMURIN_JDK_VERSION>
                         <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
                         <GOLANG_VERSION>${golang.version}</GOLANG_VERSION>
+                        <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9.crypto.policies.scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
+                        <FINDUTILS_VERSION>-${ubi9.findutils.version}</FINDUTILS_VERSION>
+                        <HOSTNAME_VERSION>-${ubi9.hostname.version}</HOSTNAME_VERSION>
                     </buildArgs>
                 </configuration>
             </plugin>
@@ -143,8 +146,9 @@
                                         ${docker.skip-security-update-check}
                                     </SKIP_SECURITY_UPDATE_CHECK>
                                     <GOLANG_VERSION>${golang.version}</GOLANG_VERSION>
-                                    <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi.crypto.policies.scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
-                                    <FINDUTILS_VERSION>-${ubi.iputils.version}</FINDUTILS_VERSION>
+                                    <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9.crypto.policies.scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
+                                    <FINDUTILS_VERSION>-${ubi9.findutils.version}</FINDUTILS_VERSION>
+                                    <HOSTNAME_VERSION>-${ubi9.hostname.version}</HOSTNAME_VERSION>
                                 </args>
                             </build>
                         </image>

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -286,7 +286,7 @@ func loadConfigSpec(path string) (ConfigSpec, error) {
 }
 
 func invokeJavaCommand(className string, jvmOpts string, args []string) bool {
-	classPath := getEnvOrDefault("UB_CLASSPATH", "/usr/share/java/cp-base-lite/*")
+	classPath := getEnvOrDefault("UB_CLASSPATH", "/usr/share/java/cp-base-java/*")
 
 	opts := []string{}
 	if jvmOpts != "" {


### PR DESCRIPTION
### Change Description
This PR does the following changes
1. installs hostname package in cp-base-java image, hostname is getting used in most of CP docker images to set a default IP for <COMPONENT>_JMX_HOSTNAME env variable.
2. fixes the ARGS defined in base-java maven pom.xml
3. fixes the default path for ub.go in base-java module

### Testing
Testing done through semaphoreCI PR builds
