### PR TITLE
CPBR-1863 add functionality for set_properties and its variants to ub script

### DIFF
--- a/base-java/ub/testResources/sampleLog4j.template
+++ b/base-java/ub/testResources/sampleLog4j.template
@@ -10,7 +10,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.logger.{{ $k }}={{ $v -}}
 {{ end }}
 
-{{- $kr_props := envToProps "LOG4J_" "" nil -}}
+{{- $kr_props := envToProps "LOG4J_" "" nil nil -}}
 {{ range $k, $v := $kr_props }}
 {{ $k }}={{ $v }}
 {{ end }}

--- a/base-java/ub/testResources/sampleLog4j.template
+++ b/base-java/ub/testResources/sampleLog4j.template
@@ -10,7 +10,7 @@ log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.logger.{{ $k }}={{ $v -}}
 {{ end }}
 
-{{- $kr_props := envToProps "LOG4J_" "" nil nil -}}
+{{- $kr_props := envToProps "LOG4J_" "" nil nil nil -}}
 {{ range $k, $v := $kr_props }}
 {{ $k }}={{ $v }}
 {{ end }}

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -307,14 +307,14 @@ func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string, excl
 	return config
 }
 
-func setProperties(properties map[string][]string, required bool, excludes []string) map[string]string {
+func setProperties(properties map[string][]string, required bool, excludeEnvs []string) map[string]string {
 	result := make(map[string]string)
 	env := GetEnvironment()
 
 	for property, propertyTranslationList := range properties {
 		var nsResult string
 		for _, envVar := range propertyTranslationList {
-			if slices.Contains(excludes, envVar) {
+			if slices.Contains(excludeEnvs, envVar) {
 				nsResult = ""
 				break
 			}

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -263,10 +263,10 @@ func buildProperties(spec ConfigSpec, environment map[string]string) map[string]
 	return config
 }
 
-func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPrefix, propPrefix string, excludes []string) map[string]string {
+func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPrefix, propPrefix string, excludes []string, excludeProps []string) map[string]string {
 	result := make(map[string]string)
-	primaryProps := envToProps(primaryEnvPrefix, propPrefix, excludes, nil)
-	secondaryProps := envToProps(secondaryEnvPrefix, propPrefix, excludes, nil)
+	primaryProps := envToProps(primaryEnvPrefix, propPrefix, excludes, nil, excludeProps)
+	secondaryProps := envToProps(secondaryEnvPrefix, propPrefix, excludes, nil, excludeProps)
 	for name, value := range primaryProps {
 		result[name] = value
 	}
@@ -278,7 +278,7 @@ func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPr
 	return result
 }
 
-func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string, excludePropPrefixes []string) map[string]string {
+func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string, excludePropPrefixes []string, excludeProps []string) map[string]string {
 	env := GetEnvironment()
 	config := make(map[string]string)
 	for envName, envValue := range env {
@@ -289,7 +289,7 @@ func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string, excl
 			trimmedEnvName := strings.TrimPrefix(envName, envPrefix)
 			propertyName := propertyNamePrefix + ConvertKey(trimmedEnvName)
 
-			if slices.Contains(excludeEnvs, propertyName) {
+			if slices.Contains(excludeProps, propertyName) {
 				continue
 			}
 			shouldExclude := false

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -92,7 +92,6 @@ var (
 	}
 )
 
-
 // Helper function to create string slices in templates
 func stringSlice(values ...string) []string {
 	return values
@@ -298,13 +297,10 @@ func envToProps(envPrefix, propertyNamePrefix string, excludeEnvs []string, excl
 		if strings.HasPrefix(envName, envPrefix) {
 			trimmedEnvName := strings.TrimPrefix(envName, envPrefix)
 			propertyName := propertyNamePrefix + ConvertKey(trimmedEnvName)
-			
-			// Check if the property name is in excludes
+
 			if slices.Contains(excludeEnvs, propertyName) {
 				continue
 			}
-			
-			// Check if the property name starts with any of the excluded prefixes
 			shouldExclude := false
 			for _, prefix := range excludePropPrefixes {
 				if strings.HasPrefix(propertyName, prefix) {
@@ -324,22 +320,20 @@ func setProperties(properties map[string][]string, required bool, excludes []str
 	result := make(map[string]string)
 	env := GetEnvironment()
 
-	for property, ks := range properties {
+	for property, propertyTranslationList := range properties {
 		var nsResult string
 		// Find first non-empty value
-		for _, k := range ks {
-			if slices.Contains(excludes, k) {
-				// If the key is in excludes, set empty string and break
+		for _, envVar := range propertyTranslationList {
+			if slices.Contains(excludes, envVar) {
 				nsResult = ""
 				break
 			}
-			if val, exists := env[k]; exists {
+			if val, exists := env[envVar]; exists {
 				nsResult = val
 				break
 			}
 		}
 
-		// Fill the map based on conditions
 		if required {
 			result[property] = nsResult
 		} else if nsResult != "" {

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -265,25 +265,16 @@ func buildProperties(spec ConfigSpec, environment map[string]string) map[string]
 
 func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPrefix, propPrefix string, excludes []string) map[string]string {
 	result := make(map[string]string)
-
-	// Get all environment variables matching the primary prefix
 	primaryProps := envToProps(primaryEnvPrefix, propPrefix, excludes, nil)
-
-	// Get all environment variables matching the secondary prefix
 	secondaryProps := envToProps(secondaryEnvPrefix, propPrefix, excludes, nil)
-
-	// First add all properties from the primary prefix (they take precedence)
 	for name, value := range primaryProps {
 		result[name] = value
 	}
-
-	// Then add properties from the secondary prefix only if not already present
 	for name, value := range secondaryProps {
 		if _, exists := result[name]; !exists {
 			result[name] = value
 		}
 	}
-
 	return result
 }
 
@@ -322,7 +313,6 @@ func setProperties(properties map[string][]string, required bool, excludes []str
 
 	for property, propertyTranslationList := range properties {
 		var nsResult string
-		// Find first non-empty value
 		for _, envVar := range propertyTranslationList {
 			if slices.Contains(excludes, envVar) {
 				nsResult = ""
@@ -333,7 +323,6 @@ func setProperties(properties map[string][]string, required bool, excludes []str
 				break
 			}
 		}
-
 		if required {
 			result[property] = nsResult
 		} else if nsResult != "" {

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -92,10 +92,6 @@ var (
 	}
 )
 
-// Helper function to create slices in templates
-func slice(values ...interface{}) []interface{} {
-	return values
-}
 
 // Helper function to create string slices in templates
 func stringSlice(values ...string) []string {
@@ -165,7 +161,6 @@ func renderTemplate(templateFilePath string) error {
 		"splitToMapDefaults":     splitToMapDefaults,
 		"envToProps":             envToProps,
 		"setProperties":          setProperties,
-		"slice":                  slice,
 		"stringSlice":            stringSlice,
 		"append":                 appendStringSlice,
 		"createStringSliceMap":   createStringSliceMap,

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -263,10 +263,10 @@ func buildProperties(spec ConfigSpec, environment map[string]string) map[string]
 	return config
 }
 
-func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPrefix, propPrefix string, excludes []string, excludeProps []string) map[string]string {
+func setPropertiesWithEnvToPropsWithTwoPrefixes(primaryEnvPrefix, secondaryEnvPrefix, propPrefix string, excludeEnvs []string, excludeProps []string) map[string]string {
 	result := make(map[string]string)
-	primaryProps := envToProps(primaryEnvPrefix, propPrefix, excludes, nil, excludeProps)
-	secondaryProps := envToProps(secondaryEnvPrefix, propPrefix, excludes, nil, excludeProps)
+	primaryProps := envToProps(primaryEnvPrefix, propPrefix, excludeEnvs, nil, excludeProps)
+	secondaryProps := envToProps(secondaryEnvPrefix, propPrefix, excludeEnvs, nil, excludeProps)
 	for name, value := range primaryProps {
 		result[name] = value
 	}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -645,7 +645,7 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 			},
 		},
 		{
-			name: "with excludes",
+			name: "with excludeEnvs",
 			args: args{
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
@@ -763,7 +763,7 @@ func Test_setProperties(t *testing.T) {
 	type args struct {
 		properties map[string][]string
 		required   bool
-		excludes   []string
+		excludeEnvs []string
 	}
 
 	tests := []struct {
@@ -781,7 +781,7 @@ func Test_setProperties(t *testing.T) {
 					"prop3": {"REQUIRED_PROP3"},
 				},
 				required: true,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"REQUIRED_PROP1": "value1",
@@ -803,7 +803,7 @@ func Test_setProperties(t *testing.T) {
 					"prop3": {"REQUIRED_PROP3"},
 				},
 				required: true,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"REQUIRED_PROP1": "value1",
@@ -824,7 +824,7 @@ func Test_setProperties(t *testing.T) {
 					"prop3": {"OPTIONAL_PROP3"},
 				},
 				required: false,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"OPTIONAL_PROP1": "value1",
@@ -846,7 +846,7 @@ func Test_setProperties(t *testing.T) {
 					"prop3": {"OPTIONAL_PROP3"},
 				},
 				required: false,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"OPTIONAL_PROP1": "value1",
@@ -858,7 +858,7 @@ func Test_setProperties(t *testing.T) {
 			},
 		},
 		{
-			name: "with excludes",
+			name: "with excludeEnvs",
 			args: args{
 				properties: map[string][]string{
 					"prop1": {"EXCLUDED_PROP1"},
@@ -866,7 +866,7 @@ func Test_setProperties(t *testing.T) {
 					"prop3": {"EXCLUDED_PROP3"},
 				},
 				required: true,
-				excludes: []string{"EXCLUDED_PROP1", "EXCLUDED_PROP3"},
+				excludeEnvs: []string{"EXCLUDED_PROP1", "EXCLUDED_PROP3"},
 			},
 			envVars: map[string]string{
 				"EXCLUDED_PROP1": "value1",
@@ -887,7 +887,7 @@ func Test_setProperties(t *testing.T) {
 					"prop2": {"PRIMARY_PROP2", "SECONDARY_PROP2"},
 				},
 				required: true,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"PRIMARY_PROP1": "value1",
@@ -907,7 +907,7 @@ func Test_setProperties(t *testing.T) {
 					"prop2.nested": {"NESTED_PROP2"},
 				},
 				required: true,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"NESTED_PROP1": "value1",
@@ -923,7 +923,7 @@ func Test_setProperties(t *testing.T) {
 			args: args{
 				properties: map[string][]string{},
 				required: true,
-				excludes: []string{},
+				excludeEnvs: []string{},
 			},
 			envVars: map[string]string{
 				"SOME_PROP": "value",
@@ -943,7 +943,7 @@ func Test_setProperties(t *testing.T) {
 				}
 			}()
 
-			got := setProperties(tt.args.properties, tt.args.required, tt.args.excludes)
+			got := setProperties(tt.args.properties, tt.args.required, tt.args.excludeEnvs)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("setProperties() = %v, want %v", got, tt.want)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -537,92 +537,11 @@ func TestEnvToProps(t *testing.T) {
 					os.Unsetenv(k)
 				}
 			}()
-			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude)
+			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude, nil)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("envToProps() = %v, want %v", result, tt.expected)
 			}
 
-		})
-	}
-}
-
-func Test_setPropertiesWithSkipPropCheck(t *testing.T) {
-	type args struct {
-		envPrefix      string
-		propPrefix     string
-		excludes       []string
-		skipPropPrefix []string
-		skipProps      []string
-	}
-
-	// Set up test environment variables
-	os.Setenv("CONTROL_CENTER_TEST1", "value1")
-	os.Setenv("CONTROL_CENTER_TEST2", "value2")
-	os.Setenv("CONTROL_CENTER_METRICS_TEST", "value3")
-	os.Setenv("CONTROL_CENTER_MONITORING_TEST", "value4")
-	os.Setenv("CONTROL_CENTER_SKIP_ME", "value5")
-
-	tests := []struct {
-		name string
-		args args
-		want map[string]string
-	}{
-		{
-			name: "basic test with no skips",
-			args: args{
-				envPrefix:      "CONTROL_CENTER_",
-				propPrefix:     "confluent.controlcenter.",
-				excludes:       []string{},
-				skipPropPrefix: []string{},
-				skipProps:      []string{},
-			},
-			want: map[string]string{
-				"confluent.controlcenter.test1":           "value1",
-				"confluent.controlcenter.test2":           "value2",
-				"confluent.controlcenter.metrics.test":    "value3",
-				"confluent.controlcenter.monitoring.test": "value4",
-				"confluent.controlcenter.skip.me":         "value5",
-			},
-		},
-		{
-			name: "test with skip prefixes",
-			args: args{
-				envPrefix:      "CONTROL_CENTER_",
-				propPrefix:     "confluent.controlcenter.",
-				excludes:       []string{},
-				skipPropPrefix: []string{"confluent.controlcenter.metrics.", "confluent.controlcenter.monitoring."},
-				skipProps:      []string{},
-			},
-			want: map[string]string{
-				"confluent.controlcenter.test1":   "value1",
-				"confluent.controlcenter.test2":   "value2",
-				"confluent.controlcenter.skip.me": "value5",
-			},
-		},
-		{
-			name: "test with skip props",
-			args: args{
-				envPrefix:      "CONTROL_CENTER_",
-				propPrefix:     "confluent.controlcenter.",
-				excludes:       []string{},
-				skipPropPrefix: []string{},
-				skipProps:      []string{"confluent.controlcenter.skip.me"},
-			},
-			want: map[string]string{
-				"confluent.controlcenter.test1":           "value1",
-				"confluent.controlcenter.test2":           "value2",
-				"confluent.controlcenter.metrics.test":    "value3",
-				"confluent.controlcenter.monitoring.test": "value4",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := setPropertiesWithSkipPropCheck(tt.args.envPrefix, tt.args.propPrefix, tt.args.excludes, tt.args.skipPropPrefix, tt.args.skipProps)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("setPropertiesWithSkipPropCheck() = %v, want %v", got, tt.want)
-			}
 		})
 	}
 }

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -596,8 +596,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				"SECONDARY_TEST2": "value4",
 			},
 			want: map[string]string{
-				"test.test1": "value1", // Primary takes precedence
-				"test.test2": "value2", // Primary takes precedence
+				"test.test1": "value1",
+				"test.test2": "value2",
 			},
 		},
 		{
@@ -614,9 +614,9 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				"SECONDARY_TEST3": "value5",
 			},
 			want: map[string]string{
-				"test.test1": "value1", // From primary
-				"test.test2": "value4", // From secondary
-				"test.test3": "value5", // From secondary
+				"test.test1": "value1",
+				"test.test2": "value4",
+				"test.test3": "value5",
 			},
 		},
 		{
@@ -634,8 +634,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				"SECONDARY_TEST2": "value4",
 			},
 			want: map[string]string{
-				"test.test1": "value3", // From secondary because primary is excluded
-				"test.test2": "value2", // From primary
+				"test.test1": "value3",
+				"test.test2": "value2",
 			},
 		},
 		{
@@ -764,7 +764,7 @@ func Test_setProperties(t *testing.T) {
 			want: map[string]string{
 				"prop1": "value1",
 				"prop2": "value2",
-				"prop3": "", // Empty string for required but missing
+				"prop3": "",
 			},
 		},
 		{
@@ -807,7 +807,6 @@ func Test_setProperties(t *testing.T) {
 			want: map[string]string{
 				"prop1": "value1",
 				"prop2": "value2",
-				// prop3 not included because it's optional and missing
 			},
 		},
 		{
@@ -827,9 +826,9 @@ func Test_setProperties(t *testing.T) {
 				"EXCLUDED_PROP3": "value3",
 			},
 			want: map[string]string{
-				"prop1": "", // Empty string because EXCLUDED_PROP1 is excluded
+				"prop1": "",
 				"prop2": "value2",
-				"prop3": "", // Empty string because EXCLUDED_PROP3 is excluded
+				"prop3": "",
 			},
 		},
 		{
@@ -848,8 +847,8 @@ func Test_setProperties(t *testing.T) {
 				"PRIMARY_PROP2": "value3",
 			},
 			want: map[string]string{
-				"prop1": "value1", // Uses first available value
-				"prop2": "value3", // Uses first available value
+				"prop1": "value1",
+				"prop2": "value3",
 			},
 		},
 		{
@@ -887,12 +886,10 @@ func Test_setProperties(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set up environment variables
 			for k, v := range tt.envVars {
 				os.Setenv(k, v)
 			}
 			defer func() {
-				// Clean up environment variables
 				for k := range tt.envVars {
 					os.Unsetenv(k)
 				}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -466,7 +466,7 @@ func TestEnvToProps(t *testing.T) {
 		envVars           map[string]string
 		envPrefix         string
 		propPrefix        string
-		exclude           []string
+		excludeEnvs       []string
 		excludePropPrefix []string
 		excludeProps      []string
 		expected          map[string]string
@@ -480,7 +480,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.",
-			exclude:           []string{},
+			excludeEnvs:       []string{},
 			excludePropPrefix: nil,
 			excludeProps:      nil,
 			expected: map[string]string{
@@ -497,7 +497,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.",
-			exclude:           []string{"APP_SECRET"},
+			excludeEnvs:       []string{"APP_SECRET"},
 			excludePropPrefix: nil,
 			excludeProps:      nil,
 			expected: map[string]string{
@@ -514,7 +514,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.meta.",
-			exclude:           []string{},
+			excludeEnvs:       []string{},
 			excludePropPrefix: nil,
 			excludeProps:      nil,
 			expected: map[string]string{
@@ -530,7 +530,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.",
-			exclude:           []string{},
+			excludeEnvs:       []string{},
 			excludePropPrefix: nil,
 			excludeProps:      nil,
 			expected:          map[string]string{},
@@ -544,7 +544,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.",
-			exclude:           []string{},
+			excludeEnvs:       []string{},
 			excludePropPrefix: []string{"app.test"},
 			excludeProps:      nil,
 			expected: map[string]string{
@@ -561,7 +561,7 @@ func TestEnvToProps(t *testing.T) {
 			},
 			envPrefix:         "APP_",
 			propPrefix:        "app.",
-			exclude:           []string{},
+			excludeEnvs:       []string{},
 			excludePropPrefix: nil,
 			excludeProps:      []string{"app.foo.bar"},
 			expected: map[string]string{
@@ -581,7 +581,7 @@ func TestEnvToProps(t *testing.T) {
 					os.Unsetenv(k)
 				}
 			}()
-			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude, tt.excludePropPrefix, tt.excludeProps)
+			result := envToProps(tt.envPrefix, tt.propPrefix, tt.excludeEnvs, tt.excludePropPrefix, tt.excludeProps)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("envToProps() = %v, want %v", result, tt.expected)
 			}
@@ -594,8 +594,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 		primaryEnvPrefix   string
 		secondaryEnvPrefix string
 		propPrefix         string
-		excludes           []string
-		excludeProps       []string
+		excludeEnvs        []string
+		excludePropPrefix  []string
 	}
 
 	tests := []struct {
@@ -610,8 +610,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{},
-				excludeProps:       nil,
+				excludeEnvs:        []string{},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"PRIMARY_TEST1":   "value1",
@@ -630,8 +630,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{},
-				excludeProps:       nil,
+				excludeEnvs:        []string{},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"PRIMARY_TEST1":   "value1",
@@ -650,8 +650,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{"PRIMARY_TEST1"},
-				excludeProps:       nil,
+				excludeEnvs:        []string{"PRIMARY_TEST1"},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"PRIMARY_TEST1":   "value1",
@@ -670,8 +670,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{},
-				excludeProps:       nil,
+				excludeEnvs:        []string{},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"PRIMARY_SINGLE_UNDERSCORE":   "dot",
@@ -691,8 +691,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{},
-				excludeProps:       nil,
+				excludeEnvs:        []string{},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"OTHER_VAR1": "value1",
@@ -706,8 +706,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.meta.",
-				excludes:           []string{},
-				excludeProps:       nil,
+				excludeEnvs:        []string{},
+				excludePropPrefix:  nil,
 			},
 			envVars: map[string]string{
 				"PRIMARY_TEST1":   "value1",
@@ -724,8 +724,8 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				primaryEnvPrefix:   "PRIMARY_",
 				secondaryEnvPrefix: "SECONDARY_",
 				propPrefix:         "test.",
-				excludes:           []string{},
-				excludeProps:       []string{"test.test1"},
+				excludeEnvs:        []string{},
+				excludePropPrefix:  []string{"test.test1"},
 			},
 			envVars: map[string]string{
 				"PRIMARY_TEST1":   "value1",
@@ -751,7 +751,7 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 				}
 			}()
 
-			got := setPropertiesWithEnvToPropsWithTwoPrefixes(tt.args.primaryEnvPrefix, tt.args.secondaryEnvPrefix, tt.args.propPrefix, tt.args.excludes, tt.args.excludeProps)
+			got := setPropertiesWithEnvToPropsWithTwoPrefixes(tt.args.primaryEnvPrefix, tt.args.secondaryEnvPrefix, tt.args.propPrefix, tt.args.excludeEnvs, tt.args.excludePropPrefix)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("setPropertiesWithEnvToPropsWithTwoPrefixes() = %v, want %v", got, tt.want)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -462,7 +462,7 @@ func Test_waitForHttp(t *testing.T) {
 
 func TestEnvToProps(t *testing.T) {
 	tests := []struct {
-		name               string
+		name              string
 		envVars           map[string]string
 		envPrefix         string
 		propPrefix        string
@@ -528,7 +528,7 @@ func TestEnvToProps(t *testing.T) {
 			propPrefix:        "app.",
 			exclude:           []string{},
 			excludePropPrefix: nil,
-			expected:         map[string]string{},
+			expected:          map[string]string{},
 		},
 		{
 			name: "With property prefix exclusions",
@@ -578,7 +578,7 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 	// Set up test environment variables
 	envVars := map[string]string{
 		"PRIMARY_TEST1":   "value1",
-		"PRIMARY_TEST2":   "value2", 
+		"PRIMARY_TEST2":   "value2",
 		"SECONDARY_TEST1": "value3",
 		"SECONDARY_TEST2": "value4",
 	}
@@ -626,7 +626,7 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 					os.Unsetenv(k)
 				}
 			}()
-			
+
 			got := setPropertiesWithEnvToPropsWithTwoPrefixes(tt.args.primaryEnvPrefix, tt.args.secondaryEnvPrefix, tt.args.propPrefix, tt.args.excludes)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("setPropertiesWithEnvToPropsWithTwoPrefixes() = %v, want %v", got, tt.want)
@@ -641,12 +641,9 @@ func Test_setProperties(t *testing.T) {
 		required   bool
 		excludes   []string
 	}
-
-	// Set up test environment variables
 	os.Setenv("TEST1", "value1")
 	os.Setenv("TEST2", "value2")
 	os.Setenv("TEST3", "value3")
-
 	tests := []struct {
 		name string
 		args args

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -462,12 +462,13 @@ func Test_waitForHttp(t *testing.T) {
 
 func TestEnvToProps(t *testing.T) {
 	tests := []struct {
-		name       string
-		envVars    map[string]string
-		envPrefix  string
-		propPrefix string
-		exclude    []string
-		expected   map[string]string
+		name               string
+		envVars           map[string]string
+		envPrefix         string
+		propPrefix        string
+		exclude           []string
+		excludePropPrefix []string
+		expected          map[string]string
 	}{
 		{
 			name: "Basic conversion with prefix",
@@ -476,9 +477,10 @@ func TestEnvToProps(t *testing.T) {
 				"APP_BAZ":     "value2",
 				"OTHER_VAR":   "ignored",
 			},
-			envPrefix:  "APP_",
-			propPrefix: "app.",
-			exclude:    []string{},
+			envPrefix:         "APP_",
+			propPrefix:        "app.",
+			exclude:           []string{},
+			excludePropPrefix: nil,
 			expected: map[string]string{
 				"app.foo.bar": "value1",
 				"app.baz":     "value2",
@@ -491,9 +493,10 @@ func TestEnvToProps(t *testing.T) {
 				"APP_SECRET":  "hidden",
 				"APP_BAZ":     "value2",
 			},
-			envPrefix:  "APP_",
-			propPrefix: "app.",
-			exclude:    []string{"APP_SECRET"},
+			envPrefix:         "APP_",
+			propPrefix:        "app.",
+			exclude:           []string{"APP_SECRET"},
+			excludePropPrefix: nil,
 			expected: map[string]string{
 				"app.foo.bar": "value1",
 				"app.baz":     "value2",
@@ -506,9 +509,10 @@ func TestEnvToProps(t *testing.T) {
 				"APP_DOUBLE__UNDERSCORE":  "single_underscore",
 				"APP_TRIPLE___UNDERSCORE": "dash",
 			},
-			envPrefix:  "APP_",
-			propPrefix: "app.meta.",
-			exclude:    []string{},
+			envPrefix:         "APP_",
+			propPrefix:        "app.meta.",
+			exclude:           []string{},
+			excludePropPrefix: nil,
 			expected: map[string]string{
 				"app.meta.single.underscore": "dot",
 				"app.meta.double_underscore": "single_underscore",
@@ -520,10 +524,27 @@ func TestEnvToProps(t *testing.T) {
 			envVars: map[string]string{
 				"OTHER_VAR": "ignored",
 			},
-			envPrefix:  "APP_",
-			propPrefix: "app.",
-			exclude:    []string{},
-			expected:   map[string]string{},
+			envPrefix:         "APP_",
+			propPrefix:        "app.",
+			exclude:           []string{},
+			excludePropPrefix: nil,
+			expected:         map[string]string{},
+		},
+		{
+			name: "With property prefix exclusions",
+			envVars: map[string]string{
+				"APP_FOO_BAR":    "value1",
+				"APP_TEST_VALUE": "test",
+				"APP_BAZ":        "value2",
+			},
+			envPrefix:         "APP_",
+			propPrefix:        "app.",
+			exclude:           []string{},
+			excludePropPrefix: []string{"app.test"},
+			expected: map[string]string{
+				"app.foo.bar": "value1",
+				"app.baz":     "value2",
+			},
 		},
 	}
 
@@ -537,7 +558,7 @@ func TestEnvToProps(t *testing.T) {
 					os.Unsetenv(k)
 				}
 			}()
-			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude, nil)
+			result := envToProps(tt.envPrefix, tt.propPrefix, tt.exclude, tt.excludePropPrefix)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("envToProps() = %v, want %v", result, tt.expected)
 			}
@@ -555,10 +576,12 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 	}
 
 	// Set up test environment variables
-	os.Setenv("PRIMARY_TEST1", "value1")
-	os.Setenv("PRIMARY_TEST2", "value2")
-	os.Setenv("SECONDARY_TEST1", "value3")
-	os.Setenv("SECONDARY_TEST2", "value4")
+	envVars := map[string]string{
+		"PRIMARY_TEST1":   "value1",
+		"PRIMARY_TEST2":   "value2", 
+		"SECONDARY_TEST1": "value3",
+		"SECONDARY_TEST2": "value4",
+	}
 
 	tests := []struct {
 		name string
@@ -595,6 +618,15 @@ func Test_setPropertiesWithEnvToPropsWithTwoPrefixes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range envVars {
+				os.Setenv(k, v)
+			}
+			defer func() {
+				for k := range envVars {
+					os.Unsetenv(k)
+				}
+			}()
+			
 			got := setPropertiesWithEnvToPropsWithTwoPrefixes(tt.args.primaryEnvPrefix, tt.args.secondaryEnvPrefix, tt.args.propPrefix, tt.args.excludes)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("setPropertiesWithEnvToPropsWithTwoPrefixes() = %v, want %v", got, tt.want)


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
add functionality for 
1. setProperties 
2. setPropertiesWithSkipPropCheck
3. setPropertiesWithEnvToPropsWithTwoPrefixes

C3 template changes are part of https://github.com/confluentinc/control-center-next-gen-images/pull/10

### Testing
<!-- a description of how you tested the change -->
Added tests in ub_test.go to test various combinations with excludes and required properties
