### PR TITLE
Pin to JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     </modules>
 
     <properties>
+        <java.version>17</java.version>
         <docker.ubi8.os_type>ubi8</docker.ubi8.os_type>
         <docker.ubi9.os_type>ubi9</docker.ubi9.os_type>
         <docker.file>Dockerfile.${docker.ubi9.os_type}</docker.file>


### PR DESCRIPTION
### Change Description
Pin JDK to 17 since common will use 11 (since some clients rely on common)

### Testing
<!-- a description of how you tested the change -->
