### PR TITLE
Update jdk and ubi base image versions as part of pre-RC checklist for CP 8.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         <io.confluent.common-docker.version>8.0.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi8.image.version>8.10-1179.1741863533</ubi8.image.version>
-        <ubi9.micro.image.version>9.5-1739467664</ubi9.micro.image.version>
-        <ubi9.minimal.image.version>9.5-1739420147</ubi9.minimal.image.version>
+        <ubi9.micro.image.version>9.5-1744118077</ubi9.micro.image.version>
+        <ubi9.minimal.image.version>9.5-1742914212</ubi9.minimal.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
@@ -72,7 +72,7 @@
         <ubi8.findutils.version>1:4.6.0-21.el8</ubi8.findutils.version>
         <ubi8.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi8.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.temurin.jdk.version>21.0.6.0.0.7-1</ubi.temurin.jdk.version>
+        <ubi.temurin.jdk.version>21.0.7.0.0.6-0</ubi.temurin.jdk.version>
         <!-- Python Module Versions -->
         <ubi8.python.pip.version>20.*</ubi8.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
This PR updates the jdk and ubi base image versions as part of pre-RC checklist for CP 8.0.x

confluent-docker-utils tag is already updated to the latest version.

<img width="816" alt="image" src="https://github.com/user-attachments/assets/aa15c2c3-c3c6-43f5-a104-b230541b00b6" />
<img width="816" alt="image" src="https://github.com/user-attachments/assets/07601642-d580-4cb7-90d0-94e7d81ee136" />
<img width="816" alt="image" src="https://github.com/user-attachments/assets/20f8e0af-3475-4027-a4ac-591d98e77e51" />
<img width="769" alt="image" src="https://github.com/user-attachments/assets/fcceadc2-37f3-43fa-81e6-75136b1e6b63" />
<img width="366" alt="image" src="https://github.com/user-attachments/assets/d589071b-5a8e-437e-988c-4ce4d3afbcd4" />




### Testing
PR checks