### PR TITLE
Update ubi base image versions as part of pre-RC checklist 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi9.os_type}</docker.tag>
         <io.confluent.common-docker.version>8.0.0-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1179.1741863533</ubi8.image.version>
-        <ubi9.micro.image.version>9.5-1744118077</ubi9.micro.image.version>
+        <ubi8.image.version>8.10-1255</ubi8.image.version>
+        <ubi9.micro.image.version>9.5-1746002938</ubi9.micro.image.version>
         <ubi9.minimal.image.version>9.5-1745855087</ubi9.minimal.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>


### PR DESCRIPTION
As part of https://github.com/confluentinc/common-docker/pull/728, we updated the jdk and ubi base image versions as part of pre-RC checklist for CP 8.0.x .

However, there are newer versions of base images been made available recently.

<img width="869" alt="image" src="https://github.com/user-attachments/assets/7391916f-d042-4aa1-bc77-beada1a2431c" />

ubi 9 minimal tag was already updated to latest version
<img width="869" alt="image" src="https://github.com/user-attachments/assets/f17b4f26-94ae-498e-83cf-f66cff5da39d" />

<img width="869" alt="image" src="https://github.com/user-attachments/assets/c3a4f1b3-d3a6-47a9-bb88-38c9abbe6e94" />

JDK version needs no update, already points to latest
<img width="869" alt="image" src="https://github.com/user-attachments/assets/fe2e2777-f313-4c73-89bf-a108a7b610ef" />

confluent-docker-utils tag needs no update, already points to latest