### PR TITLE
Update jdk and ubi8 minimal base os image versions 7.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi8.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.2.15-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1179.1741863533</ubi8.image.version>
+        <ubi8.image.version>8.10-1255</ubi8.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi8.wget.version>1.19.5-12.el8_10</ubi8.wget.version>
@@ -47,7 +47,7 @@
         <ubi8.glibc.version>2.28-251.el8_10.16</ubi8.glibc.version>
         <ubi8.curl.version>7.61.1-34.el8_10.3</ubi8.curl.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>11.0.26-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>11.0.27-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi8.python.pip.version>20.*</ubi8.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
Updating the jdk and ubi8 minimal base image versions .


<img width="869" alt="image" src="https://github.com/user-attachments/assets/7391916f-d042-4aa1-bc77-beada1a2431c" />

JDK version also updated to latest.

