### PR TITLE
Update jdk and ubi8 minimal base os image versions 7.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi8.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.8.3-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1179.1741863533</ubi8.image.version>
+        <ubi8.image.version>8.10-1255</ubi8.image.version>
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
@@ -51,7 +51,7 @@
         <ubi8.findutils.version>1:4.6.0-21.el8</ubi8.findutils.version>
         <ubi8.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi8.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.temurin.jdk.version>17.0.14.0.0.7-1</ubi.temurin.jdk.version>
+        <ubi.temurin.jdk.version>17.0.15.0.0.6-0</ubi.temurin.jdk.version>
         <!-- Python Module Versions -->
         <ubi8.python.pip.version>20.*</ubi8.python.pip.version>
         <ubi.python.setuptools.version>71.1.0</ubi.python.setuptools.version>


### PR DESCRIPTION
Updating the jdk and ubi8 minimal base image versions .


<img width="869" alt="image" src="https://github.com/user-attachments/assets/7391916f-d042-4aa1-bc77-beada1a2431c" />

JDK version also updated to latest.

