### PR TITLE
CPBR-2546: removing temurin jdk repo after installing jdk

### DIFF
--- a/base-lite/Dockerfile.ubi8
+++ b/base-lite/Dockerfile.ubi8
@@ -74,7 +74,8 @@ RUN microdnf --nodocs install yum \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs
+    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
+    && rm /etc/yum.repos.d/adoptium.repo # Remove temurin-jdk repo to reduce intermittent build failures
 
 # This is a step that will cause the build to fail of the package manager detects a package update is availible and isn't installed.
 # The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
@@ -83,7 +84,7 @@ RUN microdnf --nodocs install yum \
 # security update is availible. We skip checks from TemurinJDK repos because Confluent pins those upstream versions for various reasons
 # such as identified bugs in TemurinJDK's software.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum --disablerepo="temurin-jdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -135,7 +135,8 @@ RUN microdnf --nodocs install yum \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
-    && chown appuser:appuser -R /etc/confluent/ /usr/logs
+    && chown appuser:appuser -R /etc/confluent/ /usr/logs \
+    && rm /etc/yum.repos.d/adoptium.repo # Remove temurin-jdk repo to reduce intermittent build failures
 
 # enable FIPS in docker image, this will only work if underlying OS has FIPS enabled as well else is a NO OP.
 RUN update-crypto-policies --set FIPS
@@ -147,7 +148,7 @@ RUN update-crypto-policies --set FIPS
 # security update is availible. We skip checks from TemurinJDK repos because Confluent pins those upstream versions for various reasons
 # such as identified bugs in TemurinJDK's software.
 ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum --disablerepo="temurin-jdk" check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
+RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/


### PR DESCRIPTION
### Change Description
Errors are coming in docker build pipelines for downloading metadata for yum repo for temurin jdk. These error will keep on coming in common-docker repo which builds the base image. But to reduce this flakiness in downstream repos, this PR removes the `.repo` file created for installing JDK in the docker image.

Error logs 
```
error: cannot update repo 'temurin-jdk': Yum repo downloading error: Downloading error(s): repodata/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz - Cannot download, all mirrors were already tried without success; Last error: Status code: 403 for https://jfrog-prod-usw2-shared-oregon-main.s3.us-west-2.amazonaws.com/aol-adoptium/filestore/44/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f?response-content-disposition=attachment%3Bfilename%3D%22440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz%22&response-content-type=application%2Fx-gzip&X-Artifactory-username=anonymous&X-Artifactory-repoType=local&X-Artifactory-repositoryKey=rpm&X-Artifactory-originPackageType=yum&X-Artifactory-packageType=yum&X-Artifactory-artifactPath=rhel%2F9%2Fx86_64%2Frepodata%2F440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz&X-Artifactory-originProjectKey=temurin&X-Artifactory-projectKey=temurin&X-Artifactory-originRepoType=local&X-Artifactory-originRepositoryKey=rpm&x-jf-traceId=4f8789349f846846305f38176cc0edc7&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEHcaCXVzLXdlc3QtMiJHMEUCICTfibV8ysic%2FF1J2clnAm15exL2C2l9CsHGx72PeLpnAiEAhQjfg5UiFeSSFHrlv7mYlXyNl2%2B%2BYK0HmK%2BFwt7L3OIqhgUIIBACGgw5OTk5MzQ3OTA0MTQiDALjJnoH8dx3TOqN9irjBPEJNon8sxpSh%2FGQFfLruLJNIwvDBw9mip87I3ikqX9V0cDuGwEDpc5hDNAeyNZ591jG0%2BEoHzITHVUcJSUOE4rw71m986IlArZBv3%2FpMgcaktnKe9YA6PGqFlMIeVtQYrFmC%2Fs5xRcOmnAkDa%2BTSnU3YmvsMstWw19Obw%2FIngQD6TPSdsZRoR8Etis%2FJfmhbHArsAmwyT2yRBT8qFhSV89xHN9E9tUAWC5RJDw7LkYS93LbW%2BeGrJdeMrJ%2F%2Bo6ZcVmy2%2Fav0HBNMiYLCDQY7pMjKXjy8kk9w363wnmcYUN88I%2Bz7h22mbRYnEJWf8C7fAbQ7dQGR4mS1nPFdjaSr6RoZCtD56tgZfYZNwWPv5zbrPHeZupucTn6C2a25kCQiWbY4TReOlSYMDUoG3JzJTADe2%2BojreZ5IfMJPFOwA5%2FH7uoukb6FzaGyCCKdDbdlr%2Fg66g6i48dm62kYpqn2IAzLQqfSBcvHFdy0MwxDeB%2BQZ69HCTnKp7QmZaIzczN9ynIe4OnGHEnsyiVvMB4JIRpgD8ibtrpDHuO6vBJhNCRO%2B%2BBUlDyNMFfdz6Ao6Y%2FqI%2F9OQHdystRQjUXIWLp2RzRd4ZJVJehK0CCtNgA8KyEpTZ28MV8BKuGPctB4z8jxFupd5mkSPwumIA5TZWKZvEwObDUKtwYvz%2B8p6Je8294ONTK1GsUQMsOteFcjHLZyJcwiuRg342gSt4OmWUR2SXoUaJZyTRa7hYWcsCAbxdRrS%2BHT2nWNbx35oicQQaYgZQltlY787e5%2FnK1XVaY6WCFZvlGj%2BTnFyUpF29L6r%2BE7Q2FMNHc38AGOpoBmbHQdv5AjJgRgznuaIoOT7bDvznfOpJ4eiocrRw4%2B7k8N7yu72NtR960oUxWOfvoQIQBwSNP8xCAR4rPQkIjroq1ZQujpsTJHHOopJUy%2B36IfWVAaIa1YR3csZ%2Bq0W4ULgCQQ%2BvH4S5PCv6GPfTnBmT35wDKZrHp0Nfe8ci8Y3XkqS%2BbsI8G2VPG%2FLPT67Yds2VJV8ijYNt%2FQQ%3D%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20250504T230356Z&X-Amz-SignedHeaders=host&X-Amz-Credential=ASIA6RUGCBMHKD2GJUPX%2F20250504%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Expires=900&X-Amz-Signature=2d6eb10969b9bf811fad30fa8037a0f9426e58fcc01d7d79649dff00f03fcec4 (IP: 52.92.195.106)
```

### Testing
<!-- a description of how you tested the change -->
