### PR TITLE
CPBR-2546: removing temurin-jdk repo from cp-base-java

### DIFF
--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -62,7 +62,8 @@ RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && chown appuser:appuser -R /etc/confluent/ /usr/logs \
-    && mkdir /licenses
+    && mkdir /licenses \
+    && rm /etc/yum.repos.d/adoptium.repo # Remove temurin-jdk repo to reduce intermittent build failures
 
 # enable FIPS in docker image, this will only work if underlying OS has FIPS enabled as well else is a NO OP.
 RUN update-crypto-policies --set FIPS
@@ -71,6 +72,14 @@ COPY license.txt /licenses
 COPY --from=build-ub-package-dedupe /build/package_dedupe/package_dedupe /usr/bin/package_dedupe
 COPY --from=build-ub-package-dedupe /build/ub/ub /usr/bin/ub
 
+# This is a step that will cause the build to fail of the package manager detects a package update is availible and isn't installed.
+# The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
+# is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the left
+# hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
+# security update is availible. We skip checks from TemurinJDK repos because Confluent pins those upstream versions for various reasons
+# such as identified bugs in TemurinJDK's software.
+ARG SKIP_SECURITY_UPDATE_CHECK="false"
+RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
 
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/

--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -72,15 +72,6 @@ COPY license.txt /licenses
 COPY --from=build-ub-package-dedupe /build/package_dedupe/package_dedupe /usr/bin/package_dedupe
 COPY --from=build-ub-package-dedupe /build/ub/ub /usr/bin/ub
 
-# This is a step that will cause the build to fail of the package manager detects a package update is availible and isn't installed.
-# The ARG SKIP_SECURITY_UPDATE_CHECK is an "escape" hatch if you want to by-pass this check and build the container anyways, which
-# is not advisable in terms of security posture. If set to false (which triggers a shell exit(1) if the check fails from the left
-# hand of ||) this check will fail. If true (which triggers a right-hand || shell exit(0)), then this check will pass even if a
-# security update is availible. We skip checks from TemurinJDK repos because Confluent pins those upstream versions for various reasons
-# such as identified bugs in TemurinJDK's software.
-ARG SKIP_SECURITY_UPDATE_CHECK="false"
-RUN yum check-update || "${SKIP_SECURITY_UPDATE_CHECK}"
-
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker


### PR DESCRIPTION
### Change Description
This PR makes similar changes as done in for removing temurin repo for cp-base-java as it is introduced in 8.0.x https://github.com/confluentinc/common-docker/pull/738.

### Testing
AMD64 build is passing in SemaphoreCI. Arm64 is failing on temurin-jdk metadata download
