### PR TITLE
Update ubi9 micro base os image versions 7.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <io.confluent.common-docker.version>7.9.1-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi8.image.version>8.10-1255</ubi8.image.version>
-        <ubi9.micro.image.version>9.5-1739467664</ubi9.micro.image.version>
+        <ubi9.micro.image.version>9.5-1746002938</ubi9.micro.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->


### PR DESCRIPTION
Updating the ubi9 micro base os image versions .

<img width="869" alt="image" src="https://github.com/user-attachments/assets/2f3e7fbd-dd7c-46d7-a843-ac342a6ccb8b" />

