### PR TITLE
Fix temurin jdk repo url path

### DIFF
--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -47,10 +47,10 @@ ENV USE_LOG4J_2="True"
 
 RUN printf "[temurin-jre] \n\
 name=temurin-jre \n\
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
 enabled=1 \n\
 gpgcheck=1 \n\
-gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
 RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \


### PR DESCRIPTION
### Change Description
We've been intermittently seeing issues with common-docker build failing because of temurin jdk repo.
Error -
```
[INFO] error: cannot update repo 'temurin-jdk': Yum repo downloading error: Downloading error(s): repodata/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz - Cannot download, all mirrors were already tried without success; Last error: Status code: 403 for https://jfrog-prod-usw2-shared-oregon-main.s3.us-west-2.amazonaws.com/aol-adoptium/filestore/44/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f?response-content-disposition=attachment%3Bfilename%3D%22440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz%22&response-content-type=application%2Fx-gzip&X-Artifactory-username=anonymous&X-Artifactory-repoType=local&X-Artifactory-repositoryKey=rpm&X-Artifactory-originPackageType=yum&X-Artifactory-packageType=yum&X-Artifactory-artifactPath=rhel%2F9%2Fx86_64%2Frepodata%2F440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz&X-Artifactory-originProjectKey=temurin&X-Artifactory-projectKey=temurin&X-Artifactory-originRepoType=local&X-Artifactory-originRep
```

Came across this similar adoptium issue https://github.com/adoptium/adoptium-support/issues/1285

Trying to replace packages.adoptium.net with adoptium.jfrog.io as suggested in the adoptium github issue

### Testing
PR checks
