### PR TITLE
CPBR-2575: Fix temurin jdk repo url path

### DIFF
--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -47,10 +47,10 @@ ENV USE_LOG4J_2="True"
 
 RUN printf "[temurin-jre] \n\
 name=temurin-jre \n\
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
 enabled=1 \n\
 gpgcheck=1 \n\
-gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
 RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \

--- a/base-lite/Dockerfile.ubi9
+++ b/base-lite/Dockerfile.ubi9
@@ -59,10 +59,10 @@ ENV UB_CLASSPATH=/usr/share/java/cp-base-lite/*
 
 RUN printf "[temurin-jdk] \n\
 name=temurin-jdk \n\
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
 enabled=1 \n\
 gpgcheck=1 \n\
-gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
 RUN microdnf --nodocs -y install yum \

--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -79,10 +79,10 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluent
 
 RUN printf "[temurin-jdk] \n\
 name=temurin-jdk \n\
-baseurl=https://packages.adoptium.net/artifactory/rpm/rhel/\$releasever/\$basearch \n\
+baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
 enabled=1 \n\
 gpgcheck=1 \n\
-gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public \n\
+gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
 # ENV required when manually installing openssl,

--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,16 @@
         <!-- Redhat Package Versions -->
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
-        <ubi9.python39.version>3.9.21-1.el9_5</ubi9.python39.version>
+        <ubi9.python39.version>3.9.21-2.el9</ubi9.python39.version>
         <ubi9.tar.version>1.34-7.el9</ubi9.tar.version>
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
         <ubi9.procps.version>3.3.17-14.el9</ubi9.procps.version>
-        <ubi9.krb5.workstation.version>1.21.1-4.el9_5</ubi9.krb5.workstation.version>
-        <ubi9.iputils.version>20210202-10.el9_5</ubi9.iputils.version>
+        <ubi9.krb5.workstation.version>1.21.1-6.el9</ubi9.krb5.workstation.version>
+        <ubi9.iputils.version>20210202-11.el9</ubi9.iputils.version>
         <ubi9.hostname.version>3.23-6.el9</ubi9.hostname.version>
         <ubi9.xzlibs.version>5.2.5-8.el9_0</ubi9.xzlibs.version>
-        <ubi9.glibc.version>2.34-125.el9_5.8</ubi9.glibc.version>
+        <ubi9.glibc.version>2.34-168.el9_6.14</ubi9.glibc.version>
         <ubi9.findutils.version>1:4.8.0-7.el9</ubi9.findutils.version>
         <ubi9.crypto.policies.scripts.version>20240828-2.git626aa59.el9_5</ubi9.crypto.policies.scripts.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
### Change Description

cherry-pick of https://github.com/confluentinc/common-docker/pull/743 and https://github.com/confluentinc/common-docker/pull/742

We've been intermittently seeing issues with common-docker build failing because of temurin jdk repo.
Error -
```
[INFO] error: cannot update repo 'temurin-jdk': Yum repo downloading error: Downloading error(s): repodata/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz - Cannot download, all mirrors were already tried without success; Last error: Status code: 403 for https://jfrog-prod-usw2-shared-oregon-main.s3.us-west-2.amazonaws.com/aol-adoptium/filestore/44/440aef5fdd7a7c3c65d6d57390a4a590fea8df0f?response-content-disposition=attachment%3Bfilename%3D%22440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz%22&response-content-type=application%2Fx-gzip&X-Artifactory-username=anonymous&X-Artifactory-repoType=local&X-Artifactory-repositoryKey=rpm&X-Artifactory-originPackageType=yum&X-Artifactory-packageType=yum&X-Artifactory-artifactPath=rhel%2F9%2Fx86_64%2Frepodata%2F440aef5fdd7a7c3c65d6d57390a4a590fea8df0f-filelists.xml.gz&X-Artifactory-originProjectKey=temurin&X-Artifactory-projectKey=temurin&X-Artifactory-originRepoType=local&X-Artifactory-originRep
```

Similar adoptium issue https://github.com/adoptium/adoptium-support/issues/1285

This PR replaces packages.adoptium.net with adoptium.jfrog.io as suggested in the adoptium github issue

This PR also updates python, krb5, iputils, glibc versions to resolve the 
`[INFO] Error: Unable to find a match: python3-3.9.21-1.el9_5 krb5-workstation-1.21.1-4.el9_5 iputils-20210202-10.el9_5 glibc-common-2.34-125.el9_5.8 glibc-minimal-langpack-2.34-125.el9_5.8
` 
error in PR builds.


### Testing
PR checks
