### PR TITLE
Update ubi9 base os, fix glibc and python3 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,13 @@
         <!-- Versions-->
         <ubi8.image.version>8.10-1295.1749680713</ubi8.image.version>
         <ubi9.micro.image.version>9.6-1750858477</ubi9.micro.image.version>
-        <ubi9.minimal.image.version>9.6-1750782676</ubi9.minimal.image.version>
+        <ubi9.minimal.image.version>9.6-1751286687</ubi9.minimal.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
-        <ubi9.python39.version>3.9.21-2.el9</ubi9.python39.version>
+        <ubi9.python39.version>3.9.21-2.el9_6.1</ubi9.python39.version>
         <ubi9.tar.version>1.34-7.el9</ubi9.tar.version>
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
@@ -52,7 +52,7 @@
         <ubi9.iputils.version>20210202-11.el9_6.1</ubi9.iputils.version>
         <ubi9.hostname.version>3.23-6.el9</ubi9.hostname.version>
         <ubi9.xzlibs.version>5.2.5-8.el9_0</ubi9.xzlibs.version>
-        <ubi9.glibc.version>2.34-168.el9_6.19</ubi9.glibc.version>
+        <ubi9.glibc.version>2.34-168.el9_6.20</ubi9.glibc.version>
         <ubi9.findutils.version>1:4.8.0-7.el9</ubi9.findutils.version>
         <ubi9.crypto.policies.scripts.version>20240828-2.git626aa59.el9_5</ubi9.crypto.policies.scripts.version>
         <!-- Python Module Versions -->


### PR DESCRIPTION
This PR will update ubi9 base os image and fix the nightly semaphoreCI failure due to glibc and python version not found issue
