### PR TITLE
CPBR-2901,CPBR-2902,CPBR-2903: July Month Fedramp Release CVE fixes

### DIFF
--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.161
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.162

--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,13 @@
         <ubi.wget.version>1.19.5-12.el8_10</ubi.wget.version>
         <ubi.netcat.version>7.92-1.el8</ubi.netcat.version>
         <ubi.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi.python39.version>
-        <ubi.tar.version>1.30-9.el8</ubi.tar.version>
+        <ubi.tar.version>2:1.30-10.el8_10</ubi.tar.version>
         <ubi.procps.version>3.3.15-14.el8</ubi.procps.version>
         <ubi.krb5.workstation.version>1.18.2-32.el8_10</ubi.krb5.workstation.version>
         <ubi.iputils.version>20180629-11.el8</ubi.iputils.version>
         <ubi.hostname.version>3.20-6.el8</ubi.hostname.version>
         <ubi.xzlibs.version>5.2.4-4.el8_6</ubi.xzlibs.version>
-        <ubi.glibc.version>2.28-251.el8_10.16</ubi.glibc.version>
+        <ubi.glibc.version>2.28-251.el8_10.22</ubi.glibc.version>
         <ubi.curl.version>7.61.1-34.el8_10.3</ubi.curl.version>
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1255</ubi.image.version>
+        <ubi.image.version>8.10-1752068421</ubi.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
@@ -56,7 +56,7 @@
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>78.1.1</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.161</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.162</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
         <golang.version>1.21-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager


### PR DESCRIPTION
### Change Description
This PR aims to resolve CVEs listed in [CPBR-2901](https://confluentinc.atlassian.net/browse/CPBR-2901), [CPBR-2902](https://confluentinc.atlassian.net/browse/CPBR-2902), [CPBR-2903](https://confluentinc.atlassian.net/browse/CPBR-2903).
Requests library comes in from confluent-docker-utils and urrlib3 comes in as a dependency of requests. v0.0.162 of confluent-docker-utils has requests:2.32.4.

Base image is also updated to latest base image. zulu17-ca-jdk-headless is already at the latest version.

We also update tar and glibc versions to fix the failing PR builds.

[CPBR-2901]: https://confluentinc.atlassian.net/browse/CPBR-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPBR-2902]: https://confluentinc.atlassian.net/browse/CPBR-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPBR-2903]: https://confluentinc.atlassian.net/browse/CPBR-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ