### PR TITLE
CPBR-2662 | Updating GoLang version to fix the CVE 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <ubi.python.setuptools.version>78.1.1</ubi.python.setuptools.version>
         <ubi.python.confluent.docker.utils.version>v0.0.160</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
-        <golang.version>1.23.8</golang.version>
+        <golang.version>1.24.2-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
This PR will update the golang version to fix the CVE- https://confluentinc.atlassian.net/browse/CPBR-2662
