### PR TITLE
CPBR-2851: Update java version to latest for Jul 2025 Fedramp release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <ubi.findutils.version>1:4.6.0-21.el8</ubi.findutils.version>
         <ubi.crypto.policies.scripts.version>20230731-1.git3177e06.el8</ubi.crypto.policies.scripts.version>
         <!-- ZULU OpenJDK Package Version -->
-        <ubi.zulu.openjdk.version>17.0.15-1</ubi.zulu.openjdk.version>
+        <ubi.zulu.openjdk.version>17.0.16-1</ubi.zulu.openjdk.version>
         <!-- Python Module Versions -->
         <ubi.python.pip.version>20.*</ubi.python.pip.version>
         <ubi.python.setuptools.version>78.1.1</ubi.python.setuptools.version>


### PR DESCRIPTION
### Change Description
This PR updates the java version to latest for Jul 2025 Fedramp release - 17.0.16-1 .



### Testing
PR checks, failing PR check is flaky and not due to java version update
