### PR TITLE
CPBR-2851: Update to ubuntu24 agents for July 2025 Fedramp release

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -7,7 +7,7 @@ version: v1.0
 name: build-test-release
 agent:
   machine:
-    type: s1-prod-ubuntu20-04-amd64-1
+    type: s1-prod-ubuntu24-04-amd64-1
 
 fail_fast:
   cancel:


### PR DESCRIPTION
### Change Description
Update to ubuntu24 agents for July 2025 Fedramp release as ubuntu20 agents are decommisioned due to being EOL.
