### PR TITLE
CPBR-2892 | Update confluent-docker-utils and requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.ubi8.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.3.14-0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi8.image.version>8.10-1255</ubi8.image.version>
+        <ubi8.image.version>8.10-1752564239</ubi8.image.version>
         <!-- Redhat Package Versions -->
         <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
         <ubi8.wget.version>1.19.5-12.el8_10</ubi8.wget.version>
@@ -51,7 +51,7 @@
         <!-- Python Module Versions -->
         <ubi8.python.pip.version>20.*</ubi8.python.pip.version>
         <ubi.python.setuptools.version>78.1.1</ubi.python.setuptools.version>
-        <ubi.python.confluent.docker.utils.version>v0.0.160</ubi.python.confluent.docker.utils.version>
+        <ubi.python.confluent.docker.utils.version>v0.0.162</ubi.python.confluent.docker.utils.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
This PR will update base os and fix CVE- https://confluentinc.atlassian.net/browse/CPBR-2889 and https://confluentinc.atlassian.net/browse/CPBR-2892