### PR TITLE
Merge 7.7.x into 7.8.x and remove fips openssl version

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -123,7 +123,7 @@
                 <configuration>
                     <buildArgs>
                         <UBI_MINIMAL_VERSION>${ubi8.image.version}</UBI_MINIMAL_VERSION>
-                        <OPENSSL_VERSION>-${fips.openssl.version}</OPENSSL_VERSION>
+                        <OPENSSL_VERSION>-${ubi8.openssl.version}</OPENSSL_VERSION>
                         <WGET_VERSION>-${ubi8.wget.version}</WGET_VERSION>
                         <NETCAT_VERSION>-${ubi8.netcat.version}</NETCAT_VERSION>
                         <PYTHON39_VERSION>-${ubi8.python39.version}</PYTHON39_VERSION>
@@ -153,7 +153,7 @@
                             <build>
                                 <args>
                                     <UBI_MINIMAL_VERSION>${ubi8.image.version}</UBI_MINIMAL_VERSION>
-                                    <OPENSSL_VERSION>-${fips.openssl.version}</OPENSSL_VERSION>
+                                    <OPENSSL_VERSION>-${ubi8.openssl.version}</OPENSSL_VERSION>
                                     <WGET_VERSION>-${ubi8.wget.version}</WGET_VERSION>
                                     <NETCAT_VERSION>-${ubi8.netcat.version}</NETCAT_VERSION>
                                     <PYTHON39_VERSION>-${ubi8.python39.version}</PYTHON39_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
         <io.confluent.common-docker.version>7.8.4-0</io.confluent.common-docker.version>
         <!-- Versions-->
         <ubi8.image.version>8.10-1752564239</ubi8.image.version>
-        <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi8.openssl.version>1:1.1.1k-14.el8_6</ubi8.openssl.version>
         <ubi8.wget.version>1.19.5-12.el8_10</ubi8.wget.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <ubi8.image.version>8.10-1752564239</ubi8.image.version>
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->
-        <ubi.openssl.version>1:1.1.1k-14.el8_6</ubi.openssl.version>
+        <ubi8.openssl.version>1:1.1.1k-14.el8_6</ubi8.openssl.version>
         <ubi8.wget.version>1.19.5-12.el8_10</ubi8.wget.version>
         <ubi8.netcat.version>7.92-1.el8</ubi8.netcat.version>
         <ubi8.python39.version>3.9.20-1.module+el8.10.0+22342+478c159e</ubi8.python39.version>


### PR DESCRIPTION
PR build is failing due to fips dependent command here: https://github.com/confluentinc/common-docker/blob/7.8.x/base/Dockerfile.ubi8#L103. It will be fixed in next PR for removing openssl