### PR TITLE
Set skip check security as true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,6 @@
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as
         false to enforce the check. Users may override this behavior on the maven CLI by adding this option:
         `-Ddocker.skip-security-update-check=true` -->
-        <docker.skip-security-update-check>false</docker.skip-security-update-check>
+        <docker.skip-security-update-check>true</docker.skip-security-update-check>
     </properties>
 </project>


### PR DESCRIPTION
The skip security check is set to true temporarily since the command is failing on glib2 error whereas it is not directly installed by dockerfile but comes pre packaged within ubi8 image or installed when installing yum package.
As there is no way to specify glib2 package version, disabling this check temporarily to unblock daily nightly builds of docker image, PR will be reverted once the issue is fixed
