### PR TITLE
Update to latest ubi8 minimal docker image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <docker.tag>${io.confluent.common-docker.version}-${docker.os_type}</docker.tag>
         <io.confluent.common-docker.version>7.7.0</io.confluent.common-docker.version>
         <!-- Versions-->
-        <ubi.image.version>8.10-1752564239</ubi.image.version>
+        <ubi.image.version>8.10-1753978370</ubi.image.version>
         <!-- OpenSSL version that is FIPS compliant -->
         <fips.openssl.version>3.0.9</fips.openssl.version>
         <!-- Redhat Package Versions -->


### PR DESCRIPTION
### Change Description
Update to latest ubi8 minimal docker image for rc2 fedramp july 2025

### Testing
PR checks
