### PR TITLE
CPBR-2918 add support for kr-ready to ub

### DIFF
--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -112,7 +112,9 @@ var (
 		Use:   "sr-ready <host> <port> <timeout-secs>",
 		Short: "checks if Schema Registry is ready to accept client requests",
 		Args:  cobra.ExactArgs(3),
-		RunE:  runSchemaRegistryReadyCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSchemaRegistryReadyCmd(args)
+		},
 	}
 
 	krReadyCmd = &cobra.Command{
@@ -702,7 +704,7 @@ func runKafkaReadyCmd(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runSchemaRegistryReadyCmd(_ *cobra.Command, args []string) error {
+func runSchemaRegistryReadyCmd(args []string) error {
 	port, err := strconv.Atoi(args[1])
 	if err != nil {
 		return fmt.Errorf("error in parsing port %q: %w", args[1], err)

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -119,7 +119,9 @@ var (
 		Use:   "kr-ready <host> <port> <timeout-secs>",
 		Short: "checks if Kafka REST Proxy is ready to accept client requests",
 		Args:  cobra.ExactArgs(3),
-		RunE:  runKafkaRestReadyCmd,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runKafkaRestReadyCmd(args)
+		},
 	}
 
 	listenersCmd = &cobra.Command{
@@ -719,7 +721,7 @@ func runSchemaRegistryReadyCmd(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runKafkaRestReadyCmd(_ *cobra.Command, args []string) error {
+func runKafkaRestReadyCmd(args []string) error {
 	port, err := strconv.Atoi(args[1])
 	if err != nil {
 		return fmt.Errorf("error in parsing port %q: %w", args[1], err)
@@ -814,7 +816,6 @@ func main() {
 
 	krReadyCmd.PersistentFlags().StringVarP(&bootstrapServers, "bootstrap-servers", "b", "", "comma-separated list of kafka brokers")
 	krReadyCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "path to the config file")
-	krReadyCmd.PersistentFlags().StringVarP(&zookeeperConnect, "zookeeper-connect", "z", "", "zookeeper connect string")
 	krReadyCmd.PersistentFlags().StringVarP(&security, "security", "s", "", "security protocol to use when multiple listeners are enabled.")
 	krReadyCmd.PersistentFlags().BoolVarP(&krSecure, "secure", "", false, "use TLS to secure the connection")
 	krReadyCmd.PersistentFlags().BoolVarP(&krIgnoreCert, "ignore-cert", "", false, "ignore TLS certificate errors")

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -51,6 +51,12 @@ var (
 	srUsername   string
 	srPassword   string
 
+	// Kafka REST Proxy flags
+	krSecure     bool
+	krIgnoreCert bool
+	krUsername   string
+	krPassword   string
+
 	re = regexp.MustCompile("[^_]_[^_]")
 
 	ensureCmd = &cobra.Command{
@@ -107,6 +113,13 @@ var (
 		Short: "checks if Schema Registry is ready to accept client requests",
 		Args:  cobra.ExactArgs(3),
 		RunE:  runSchemaRegistryReadyCmd,
+	}
+
+	krReadyCmd = &cobra.Command{
+		Use:   "kr-ready <host> <port> <timeout-secs>",
+		Short: "checks if Kafka REST Proxy is ready to accept client requests",
+		Args:  cobra.ExactArgs(3),
+		RunE:  runKafkaRestReadyCmd,
 	}
 
 	listenersCmd = &cobra.Command{
@@ -513,6 +526,29 @@ func checkSchemaRegistryReady(host string, port int, timeout time.Duration, secu
 	return fmt.Errorf("unexpected response from schema registry with code: %d", resp.StatusCode)
 }
 
+// checkKafkaRestReady waits for Kafka REST Proxy to be ready.
+// It first checks if the service is reachable, then verifies it responds correctly
+// to a /topics request with a 2xx status code.
+func checkKafkaRestReady(host string, port int, timeout time.Duration, secure bool, ignoreCert bool, username string, password string) error {
+	status := waitForServer(host, port, timeout)
+	
+	if !status {
+		return fmt.Errorf("%s cannot be reached on port %d", host, port)
+	}
+
+	resp, err := makeRequest(host, port, secure, ignoreCert, username, password, "topics")
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	statusOK := resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+	if statusOK {
+		return nil
+	}
+	return fmt.Errorf("unexpected response with code: %d", resp.StatusCode)
+}
+
 func waitForServer(host string, port int, timeout time.Duration) bool {
 	address := fmt.Sprintf("%s:%d", host, port)
 	startTime := time.Now()
@@ -683,6 +719,23 @@ func runSchemaRegistryReadyCmd(_ *cobra.Command, args []string) error {
 	return nil
 }
 
+func runKafkaRestReadyCmd(_ *cobra.Command, args []string) error {
+	port, err := strconv.Atoi(args[1])
+	if err != nil {
+		return fmt.Errorf("error in parsing port %q: %w", args[1], err)
+	}
+	secs, err := strconv.Atoi(args[2])
+	if err != nil {
+		return fmt.Errorf("error in parsing timeout seconds %q: %w", args[2], err)
+	}
+	timeout := time.Duration(secs) * time.Second
+	err = checkKafkaRestReady(args[0], port, timeout, krSecure, krIgnoreCert, krUsername, krPassword)
+	if err != nil {
+		return fmt.Errorf("kr-ready check failed")
+	}
+	return nil
+}
+
 func parseLog4jLoggers(loggersStr string, defaultLoggers map[string]string) map[string]string {
 	if loggersStr == "" {
 		return defaultLoggers
@@ -759,6 +812,15 @@ func main() {
 	srReadyCmd.PersistentFlags().StringVarP(&srUsername, "username", "", "", "username used to authenticate to the Schema Registry")
 	srReadyCmd.PersistentFlags().StringVarP(&srPassword, "password", "", "", "password used to authenticate to the Schema Registry")
 
+	krReadyCmd.PersistentFlags().StringVarP(&bootstrapServers, "bootstrap-servers", "b", "", "comma-separated list of kafka brokers")
+	krReadyCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "path to the config file")
+	krReadyCmd.PersistentFlags().StringVarP(&zookeeperConnect, "zookeeper-connect", "z", "", "zookeeper connect string")
+	krReadyCmd.PersistentFlags().StringVarP(&security, "security", "s", "", "security protocol to use when multiple listeners are enabled.")
+	krReadyCmd.PersistentFlags().BoolVarP(&krSecure, "secure", "", false, "use TLS to secure the connection")
+	krReadyCmd.PersistentFlags().BoolVarP(&krIgnoreCert, "ignore-cert", "", false, "ignore TLS certificate errors")
+	krReadyCmd.PersistentFlags().StringVarP(&krUsername, "username", "", "", "username used to authenticate to the Kafka REST Proxy")
+	krReadyCmd.PersistentFlags().StringVarP(&krPassword, "password", "", "", "password used to authenticate to the Kafka REST Proxy")
+
 	rootCmd.AddCommand(pathCmd)
 	rootCmd.AddCommand(ensureCmd)
 	rootCmd.AddCommand(renderTemplateCmd)
@@ -767,6 +829,7 @@ func main() {
 	rootCmd.AddCommand(httpReadyCmd)
 	rootCmd.AddCommand(kafkaReadyCmd)
 	rootCmd.AddCommand(srReadyCmd)
+	rootCmd.AddCommand(krReadyCmd)
 	rootCmd.AddCommand(listenersCmd)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1305,13 +1305,7 @@ func Test_runSchemaRegistryReadyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			cmd.Flags().Bool("secure", false, "")
-			cmd.Flags().Bool("ignore-cert", false, "")
-			cmd.Flags().String("username", "", "")
-			cmd.Flags().String("password", "", "")
-
-			err := runSchemaRegistryReadyCmd(cmd, tt.args)
+			err := runSchemaRegistryReadyCmd(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runSchemaRegistryReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1443,13 +1443,7 @@ func Test_runKafkaRestReadyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			cmd.Flags().Bool("secure", false, "")
-			cmd.Flags().Bool("ignore-cert", false, "")
-			cmd.Flags().String("username", "", "")
-			cmd.Flags().String("password", "", "")
-
-			err := runKafkaRestReadyCmd(cmd, tt.args)
+			err := runKafkaRestReadyCmd(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runKafkaRestReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1318,3 +1318,141 @@ func Test_runSchemaRegistryReadyCmd(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkKafkaRestReady(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/topics" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`["topic1","topic2"]`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	serverURL, err := url.Parse(mockServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := serverURL.Hostname()
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		host       string
+		port       int
+		timeout    time.Duration
+		secure     bool
+		ignoreCert bool
+		username   string
+		password   string
+		wantErr    bool
+	}{
+		{
+			name:       "successful kafka rest check",
+			host:       host,
+			port:       port,
+			timeout:    5 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "invalid host",
+			host:       "invalid-host",
+			port:       8082,
+			timeout:    1 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid port",
+			host:       host,
+			port:       99999,
+			timeout:    1 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkKafkaRestReady(tt.host, tt.port, tt.timeout, tt.secure, tt.ignoreCert, tt.username, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkKafkaRestReady() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_runKafkaRestReadyCmd(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/topics" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`["topic1","topic2"]`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	serverURL, err := url.Parse(mockServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := serverURL.Hostname()
+	port := serverURL.Port()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "successful kafka rest ready check",
+			args:    []string{host, port, "5"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid port",
+			args:    []string{host, "invalid-port", "5"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid timeout",
+			args:    []string{host, port, "invalid-timeout"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid host",
+			args:    []string{"invalid-host", "8082", "5"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("secure", false, "")
+			cmd.Flags().Bool("ignore-cert", false, "")
+			cmd.Flags().String("username", "", "")
+			cmd.Flags().String("password", "", "")
+
+			err := runKafkaRestReadyCmd(cmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runKafkaRestReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/spf13/cobra"
 )
 
 func assertEqual(a string, b string, t *testing.T) {


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
Added a command to check if kafka-rest proxy is ready
Added tests with combinations with valid/invalid combinations of hosts/ports

### Testing
<!-- a description of how you tested the change -->
Tested by building ub.go locally and running a kafka rest docker container and checked the kr-ready command by providing the host and port of docker container and it worked
