### PR TITLE
CPBR-2921 add control-center-ready utility and tests

### DIFF
--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -783,7 +783,7 @@ func runKafkaRestReadyCmd(args []string) error {
 	return nil
 }
 
-func runControlCenterReadyCmd(_ *cobra.Command, args []string) error {
+func runControlCenterReadyCmd(args []string) error {
 	port, err := strconv.Atoi(args[1])
 	if err != nil {
 		return fmt.Errorf("error in parsing port %q: %w", args[1], err)

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -53,7 +53,6 @@ type RequestConfig struct {
 type ComponentReadyConfig struct {
 	Endpoint           string
 	ExpectedContent    string
-	ComponentName      string
 }
 
 var (
@@ -74,7 +73,6 @@ var (
 		},
 		"kafka-rest": {
 			Endpoint:        "topics",
-			ExpectedContent: "",
 		},
 		"control-center": {
 			Endpoint:        "",

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -71,17 +71,14 @@ var (
 		"schema-registry": {
 			Endpoint:        "config",
 			ExpectedContent: "compatibilityLevel",
-			ComponentName:   "schema registry",
 		},
 		"kafka-rest": {
 			Endpoint:        "topics",
 			ExpectedContent: "",
-			ComponentName:   "kafka rest proxy",
 		},
 		"control-center": {
 			Endpoint:        "",
 			ExpectedContent: "Control Center",
-			ComponentName:   "control center",
 		},
 	}
 
@@ -718,7 +715,7 @@ func runKafkaReadyCmd(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runComponentReadyCmd(componentType string, args []string) error {
+func runComponentReadyCmd(componentName string, args []string) error {
 	port, err := strconv.Atoi(args[1])
 	if err != nil {
 		return fmt.Errorf("error in parsing port %q: %w", args[1], err)
@@ -730,9 +727,9 @@ func runComponentReadyCmd(componentType string, args []string) error {
 	}
 	timeout := time.Duration(secs) * time.Second
 
-	config, exists := componentConfigs[componentType]
+	config, exists := componentConfigs[componentName]
 	if !exists {
-		return fmt.Errorf("unknown component type: %s", componentType)
+		return fmt.Errorf("unknown component type: %s", componentName)
 	}
 
 	requestConfig := RequestConfig{
@@ -746,9 +743,9 @@ func runComponentReadyCmd(componentType string, args []string) error {
 		Timeout:    timeout,
 	}
 
-	err = checkComponentReady(config.ComponentName, requestConfig, config.ExpectedContent)
+	err = checkComponentReady(componentName, requestConfig, config.ExpectedContent)
 	if err != nil {
-		return fmt.Errorf("%s ready check failed: %w", componentType, err)
+		return fmt.Errorf("%s ready check failed: %w", componentName, err)
 	}
 	return nil
 }

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -75,7 +75,6 @@ var (
 			Endpoint:        "topics",
 		},
 		"control-center": {
-			Endpoint:        "",
 			ExpectedContent: "Control Center",
 		},
 	}

--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -563,28 +563,7 @@ func checkKafkaRestReady(host string, port int, timeout time.Duration, secure bo
 // It first checks if the service is reachable, then verifies it responds correctly
 // to a request and contains 'Control Center' in the response.
 func checkControlCenterReady(host string, port int, timeout time.Duration, secure bool, ignoreCert bool, username string, password string) error {
-	status := waitForServer(host, port, timeout)
-	
-	if !status {
-		return fmt.Errorf("control center cannot be reached on %s:%d", host, port)
-	}
-
-	resp, err := makeRequest(host, port, secure, ignoreCert, username, password, "")
-	if err != nil {
-		return fmt.Errorf("error making request to control center: %w", err)
-	}
-	defer resp.Body.Close()
-	
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("error reading response body: %w", err)
-	}
-	
-	statusOK := resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
-	if statusOK && strings.Contains(string(body), "Control Center") {
-		return nil
-	} 
-	return fmt.Errorf("unexpected response from control center with code: %d", resp.StatusCode)
+	return checkComponentReady(host, port, timeout, secure, ignoreCert, username, password, "", "Control Center", "control center")
 }
 
 func waitForServer(host string, port int, timeout time.Duration) bool {

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1205,49 +1205,49 @@ func Test_runComponentReadyCmd(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		componentType string
+		componentName string
 		args          []string
 		wantErr       bool
 	}{
 		{
 			name:          "successful schema registry ready check",
-			componentType: "schema-registry",
+			componentName: "schema-registry",
 			args:          []string{host, port, "5"},
 			wantErr:       false,
 		},
 		{
 			name:          "successful kafka rest ready check",
-			componentType: "kafka-rest",
+			componentName: "kafka-rest",
 			args:          []string{host, port, "5"},
 			wantErr:       false,
 		},
 		{
 			name:          "successful control center ready check",
-			componentType: "control-center",
+			componentName: "control-center",
 			args:          []string{host, port, "5"},
 			wantErr:       false,
 		},
 		{
 			name:          "invalid port",
-			componentType: "schema-registry",
+			componentName: "schema-registry",
 			args:          []string{host, "invalid-port", "5"},
 			wantErr:       true,
 		},
 		{
 			name:          "invalid timeout",
-			componentType: "kafka-rest",
+			componentName: "kafka-rest",
 			args:          []string{host, port, "invalid-timeout"},
 			wantErr:       true,
 		},
 		{
 			name:          "invalid host",
-			componentType: "control-center",
+			componentName: "control-center",
 			args:          []string{"invalid-host", "9021", "5"},
 			wantErr:       true,
 		},
 		{
 			name:          "unknown component type",
-			componentType: "unknown-component",
+			componentName: "unknown-component",
 			args:          []string{host, port, "5"},
 			wantErr:       true,
 		},

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1255,7 +1255,7 @@ func Test_runComponentReadyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runComponentReadyCmd(tt.componentType, tt.args)
+			err := runComponentReadyCmd(tt.componentName, tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runComponentReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1603,13 +1603,7 @@ func Test_runControlCenterReadyCmd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			cmd.Flags().Bool("secure", false, "")
-			cmd.Flags().Bool("ignore-cert", false, "")
-			cmd.Flags().String("username", "", "")
-			cmd.Flags().String("password", "", "")
-
-			err := runControlCenterReadyCmd(cmd, tt.args)
+			err := runControlCenterReadyCmd(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runControlCenterReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1318,3 +1318,177 @@ func Test_runSchemaRegistryReadyCmd(t *testing.T) {
 		})
 	}
 }
+
+func Test_checkControlCenterReady(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version":"7.4.0","name":"Control Center"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	serverURL, err := url.Parse(mockServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := serverURL.Hostname()
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		host       string
+		port       int
+		timeout    time.Duration
+		secure     bool
+		ignoreCert bool
+		username   string
+		password   string
+		wantErr    bool
+	}{
+		{
+			name:       "successful control center check",
+			host:       host,
+			port:       port,
+			timeout:    5 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    false,
+		},
+		{
+			name:       "invalid host",
+			host:       "invalid-host",
+			port:       9021,
+			timeout:    1 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid port",
+			host:       host,
+			port:       99999,
+			timeout:    1 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    true,
+		},
+		{
+			name:       "response without Control Center text",
+			host:       host,
+			port:       port,
+			timeout:    5 * time.Second,
+			secure:     false,
+			ignoreCert: false,
+			username:   "",
+			password:   "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Override the mock server for the "response without Control Center text" test
+			if tt.name == "response without Control Center text" {
+				// Create a new mock server that doesn't return "Control Center"
+				altMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/" {
+						w.WriteHeader(http.StatusOK)
+						w.Write([]byte(`{"version":"7.4.0","name":"Some Other Service"}`))
+					} else {
+						http.NotFound(w, r)
+					}
+				}))
+				defer altMockServer.Close()
+
+				altServerURL, err := url.Parse(altMockServer.URL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				tt.host = altServerURL.Hostname()
+				altPort, err := strconv.Atoi(altServerURL.Port())
+				if err != nil {
+					t.Fatal(err)
+				}
+				tt.port = altPort
+			}
+
+			err := checkControlCenterReady(tt.host, tt.port, tt.timeout, tt.secure, tt.ignoreCert, tt.username, tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkControlCenterReady() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_runControlCenterReadyCmd(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version":"7.4.0","name":"Control Center"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	serverURL, err := url.Parse(mockServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := serverURL.Hostname()
+	port := serverURL.Port()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "successful control center ready check",
+			args:    []string{host, port, "5"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid port",
+			args:    []string{host, "invalid-port", "5"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid timeout",
+			args:    []string{host, port, "invalid-timeout"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid host",
+			args:    []string{"invalid-host", "9021", "5"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().Bool("secure", false, "")
+			cmd.Flags().Bool("ignore-cert", false, "")
+			cmd.Flags().String("username", "", "")
+			cmd.Flags().String("password", "", "")
+
+			err := runControlCenterReadyCmd(cmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runControlCenterReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
Added a command to check if control-center is ready
Added tests with combinations with valid/invalid combinations of hosts/ports
Refactored code to add a generic component readiness check


### Testing
<!-- a description of how you tested the change -->
Tested by building ub.go locally and running a c3 docker container and checked the control-center-ready command by providing the host and port of docker container and it worked
