### PR TITLE
CPBR-2920 Add ksql-server-ready and connect-ready utility to ub

### DIFF
--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -81,6 +81,9 @@ var (
 			Endpoint:        "info",
 			ExpectedContent: "Ksql",
 		},
+		"connect": {
+			ExpectedContent: "version",
+		},
 	}
 
 	re = regexp.MustCompile("[^_]_[^_]")
@@ -167,6 +170,15 @@ var (
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runKsqlServerReadyCmd(args)
+		},
+	}
+
+	connectReadyCmd = &cobra.Command{
+		Use:   "connect-ready <host> <port> <timeout-secs>",
+		Short: "checks if Connect is ready to accept connector tasks",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConnectReadyCmd(args)
 		},
 	}
 
@@ -776,6 +788,10 @@ func runKsqlServerReadyCmd(args []string) error {
 	return runComponentReadyCmd("ksql-server", args)
 }
 
+func runConnectReadyCmd(args []string) error {
+	return runComponentReadyCmd("connect", args)
+}
+
 func parseLog4jLoggers(loggersStr string, defaultLoggers map[string]string) map[string]string {
 	if loggersStr == "" {
 		return defaultLoggers
@@ -870,6 +886,11 @@ func main() {
 	ksqlServerReadyCmd.PersistentFlags().StringVarP(&username, "username", "", "", "username used to authenticate to the KSQL Server")
 	ksqlServerReadyCmd.PersistentFlags().StringVarP(&password, "password", "", "", "password used to authenticate to the KSQL Server")
 
+	connectReadyCmd.PersistentFlags().BoolVarP(&secure, "secure", "", false, "use TLS to secure the connection")
+	connectReadyCmd.PersistentFlags().BoolVarP(&ignoreCert, "ignore-cert", "", false, "ignore TLS certificate errors")
+	connectReadyCmd.PersistentFlags().StringVarP(&username, "username", "", "", "username used to authenticate to the Connect")
+	connectReadyCmd.PersistentFlags().StringVarP(&password, "password", "", "", "password used to authenticate to the Connect")
+
 	rootCmd.AddCommand(pathCmd)
 	rootCmd.AddCommand(ensureCmd)
 	rootCmd.AddCommand(renderTemplateCmd)
@@ -881,6 +902,7 @@ func main() {
 	rootCmd.AddCommand(krReadyCmd)
 	rootCmd.AddCommand(controlCenterReadyCmd)
 	rootCmd.AddCommand(ksqlServerReadyCmd)
+	rootCmd.AddCommand(connectReadyCmd)
 	rootCmd.AddCommand(listenersCmd)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/base-java/ub/ub_test.go
+++ b/base-java/ub/ub_test.go
@@ -1189,7 +1189,7 @@ func Test_runComponentReadyCmd(t *testing.T) {
 			w.Write([]byte(`["topic1","topic2"]`))
 		case "/":
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"version":"7.4.0","name":"Control Center"}`))
+			w.Write([]byte(`{"version":"7.4.0","name":"Control Center","commit":"abc123","kafka_cluster_id":"cluster-123"}`))
 		case "/info":
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"version":"7.4.0","ksqlServiceId":"ksql-service","ksql":"Ksql"}`))
@@ -1233,6 +1233,12 @@ func Test_runComponentReadyCmd(t *testing.T) {
 		{
 			name:          "successful ksql server ready check",
 			componentName: "ksql-server",
+			args:          []string{host, port, "5"},
+			wantErr:       false,
+		},
+		{
+			name:          "successful connect ready check",
+			componentName: "connect",
 			args:          []string{host, port, "5"},
 			wantErr:       false,
 		},
@@ -1487,6 +1493,61 @@ func Test_runKsqlServerReadyCmd(t *testing.T) {
 			err := runKsqlServerReadyCmd(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runKsqlServerReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_runConnectReadyCmd(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"version":"7.4.0","commit":"abc123","kafka_cluster_id":"cluster-123"}`))
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer mockServer.Close()
+
+	serverURL, err := url.Parse(mockServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host := serverURL.Hostname()
+	port := serverURL.Port()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "successful connect ready check",
+			args:    []string{host, port, "5"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid port",
+			args:    []string{host, "invalid-port", "5"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid timeout",
+			args:    []string{host, port, "invalid-timeout"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid host",
+			args:    []string{"invalid-host", "8083", "5"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runConnectReadyCmd(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runConnectReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
### Change Description
<!-- a description of what you are changing and why -->
Added ksql-server-ready and connect-ready utilities to ub
Added appropriate configs and endpoints for both the utilities

### Testing
<!-- a description of how you tested the change -->
Tested by building ub.go locally and running ksql and connect docker container and checked the ksql-server-ready and connect-ready commands by providing the host and port of docker container and it worked
