### PR TITLE
Update golang version to 1.24.6-bullseye

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <ubi.python.setuptools.version>78.1.1</ubi.python.setuptools.version>
         <ubi.python.confluent.docker.utils.version>v0.0.162</ubi.python.confluent.docker.utils.version>
         <!-- Golang Version -->
-        <golang.version>1.24.2-bullseye</golang.version>
+        <golang.version>1.24.6-bullseye</golang.version>
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check
         (more accurately the check is still done, it just won't fail if an update is detected), or leave it as


### PR DESCRIPTION
### Change Description
This PR updates the golang version to 1.24.6-bullseye to resolve the CVEs:
<img width="1119" height="437" alt="image" src="https://github.com/user-attachments/assets/fcd9ef1d-1312-46e6-970c-571fbc72f6f4" />

The CVE fix needed go version 1.24.6 or higher.


### Testing
PR checks