### PR TITLE
Update parseLog4jLoggers to only require loggers string

### DIFF
--- a/base-java/ub/ub.go
+++ b/base-java/ub/ub.go
@@ -533,25 +533,25 @@ func makeRequest(host string, port int, secure bool, ignoreCert bool, username s
 	if !secure {
 		scheme = "http"
 	}
-	
+
 	url := fmt.Sprintf("%s://%s:%d/%s", scheme, host, port, path)
-	
+
 	httpClient := &http.Client{
 		Timeout: defaultHTTPTimeout,
 	}
-	
+
 	if secure && ignoreCert {
 		transport := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		httpClient.Transport = transport
 	}
-	
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}
-	
+
 	if username != "" && password != "" {
 		req.SetBasicAuth(username, password)
 	}
@@ -563,7 +563,7 @@ func makeRequest(host string, port int, secure bool, ignoreCert bool, username s
 // to a request and contains the expected content in the response.
 func checkComponentReady(componentName string, config RequestConfig, expectedContentInBody string) error {
 	status := waitForServer(config.Host, config.Port, config.Timeout)
-	
+
 	if !status {
 		return fmt.Errorf("%s cannot be reached on %s:%d", componentName, config.Host, config.Port)
 	}
@@ -573,16 +573,16 @@ func checkComponentReady(componentName string, config RequestConfig, expectedCon
 		return fmt.Errorf("error making request to %s: %w", componentName, err)
 	}
 	defer resp.Body.Close()
-	
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error reading response body: %w", err)
 	}
-	
+
 	statusOK := resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
 	if statusOK && (expectedContentInBody == "" || strings.Contains(string(body), expectedContentInBody)) {
 		return nil
-	} 
+	}
 	return fmt.Errorf("unexpected response from %s with code: %d", componentName, resp.StatusCode)
 }
 
@@ -792,14 +792,24 @@ func runConnectReadyCmd(args []string) error {
 	return runComponentReadyCmd("connect", args)
 }
 
-func parseLog4jLoggers(loggersStr string, defaultLoggers map[string]string) map[string]string {
+func parseLog4jLoggers(loggersStr string, defaultLoggers ...map[string]string) map[string]string {
+	var defaults map[string]string
+	if len(defaultLoggers) > 0 {
+		defaults = defaultLoggers[0]
+	}
+
 	if loggersStr == "" {
-		return defaultLoggers
+		if defaults != nil {
+			return defaults
+		}
+		return make(map[string]string)
 	}
 
 	result := make(map[string]string)
-	for k, v := range defaultLoggers {
-		result[k] = v
+	if defaults != nil {
+		for k, v := range defaults {
+			result[k] = v
+		}
 	}
 
 	loggers := strings.Split(loggersStr, ",")


### PR DESCRIPTION
Previously, parseLog4jLoggers required both a loggers string and a defaults map, even when defaults were not needed.
This change updates the function signature to accept only the loggers string as the required argument, while making the defaults map optional. This simplifies usage in templates where only the env string is passed, while still supporting defaults when explicitly provided. 
This will fix cp-kafka-rest test in the https://semaphore.ci.confluent.io/jobs/3688580d-2b4f-49eb-9987-1efe9e481844
