### PR TITLE
CPBR-3264: Update documentation for automated docker dependencies updates

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -138,7 +138,7 @@
                         <ZULU_OPENJDK_VERSION>-${ubi8-minimal.zulu11-ca-jdk-headless.version}</ZULU_OPENJDK_VERSION>
                         <PYTHON_PIP_VERSION>-${ubi8-minimal.python39-pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
-                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.version}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
+                        <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.tag}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                         <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
                     </buildArgs>
                 </configuration>
@@ -168,7 +168,7 @@
                           <ZULU_OPENJDK_VERSION>-${ubi8-minimal.zulu11-ca-jdk-headless.version}</ZULU_OPENJDK_VERSION>
                           <PYTHON_PIP_VERSION>-${ubi8-minimal.python39-pip.version}</PYTHON_PIP_VERSION>
                           <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
-                          <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.version}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
+                          <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.tag}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                           <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
                         </args>
                       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         3. GitHub Repository Tags:
            Pattern: git-repo.<confluentinc-repo-name>.version
-           Example: git-repo.confluent-docker-utils.version
+           Example: git-repo.confluent-docker-utils.tag
            Updates: Highest semantic version tag in format v{int}.{int}.{int} from the repository
 
         4. Docker Hub Images:


### PR DESCRIPTION
### Change Description
1. Rename python.confluent.docker.utils.version to git-repo.confluent-docker-utils.version
2. add property naming convention documentation for automated updates

### Testing
<!-- a description of how you tested the change -->
