### PR TITLE
CPBR-3276: updaing pinned versions for C3 IronBank 2.2.2 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,17 +38,17 @@
         <ubi8.image.version>8.10-1755105495</ubi8.image.version>
         <ubi9.micro.image.version>9.6-1754345610</ubi9.micro.image.version>
         <ubi9.minimal.image.version>9.6-1754584681</ubi9.minimal.image.version>
-        <ubi9.openssl.version>1:3.2.2-6.el9_5.1</ubi9.openssl.version>
+        <ubi9.openssl.version>3.5.1-4.el9_7</ubi9.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
-        <ubi9.python39.version>3.9.21-2.el9_6.2</ubi9.python39.version>
+        <ubi9.python39.version>3.9.23-2.el9</ubi9.python39.version>
         <ubi9.tar.version>1.34-7.el9</ubi9.tar.version>
         <ubi9.wget.version>1.21.1-8.el9_4</ubi9.wget.version>
         <ubi9.netcat.version>7.92-3.el9</ubi9.netcat.version>
         <ubi9.procps.version>3.3.17-14.el9</ubi9.procps.version>
         <ubi9.krb5.workstation.version>1.21.1-8.el9_6</ubi9.krb5.workstation.version>
-        <ubi9.iputils.version>20210202-11.el9_6.1</ubi9.iputils.version>
+        <ubi9.iputils.version>20210202-15.el9_7</ubi9.iputils.version>
         <ubi9.hostname.version>3.23-6.el9</ubi9.hostname.version>
         <ubi9.xzlibs.version>5.2.5-8.el9_0</ubi9.xzlibs.version>
         <ubi9.glibc.version>2.34-168.el9_6.23</ubi9.glibc.version>


### PR DESCRIPTION
### Change Description
C3++ 2.2.2 release is dependent on cp-base-java 8.0.1. IB images are not present for 8.0.1 and need post branch to succeed. 

### Testing
<!-- a description of how you tested the change -->
