### PR TITLE
CPBR-3030: Upgrade Python to 3.14 for 8.1.2-cp1

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
-      - sem-version python 3.9
+      - sem-version python 3.14
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
-      - sem-version python 3.9
+      - sem-version python 3.14
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/base-java/requirements.txt
+++ b/base-java/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.162
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.169

--- a/base-java/tox.ini
+++ b/base-java/tox.ini
@@ -6,10 +6,10 @@ toxworkdir = /var/tmp
 deps =
     -rrequirements.txt
     flake8
-    pytest == 4.6.4
-    pytest-xdist == 1.29.0
-    pytest-cov == 2.7.1
-    sphinx!=1.2b2,<2.0.0
+    pytest ~= 8.0.0
+    pytest-xdist ~= 3.0.0
+    pytest-cov ~= 4.0.0
+    sphinx ~= 7.0.0
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True

--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -54,7 +54,7 @@ ENV USE_LOG4J_2="True"
 ARG OPENSSL_VERSION=""
 ARG WGET_VERSION=""
 ARG NETCAT_VERSION=""
-ARG PYTHON39_VERSION=""
+ARG PYTHON314_VERSION=""
 ARG TAR_VERSION=""
 ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
@@ -63,12 +63,13 @@ ARG HOSTNAME_VERSION=""
 ARG XZ_LIBS_VERSION=""
 ARG GLIBC_VERSION=""
 ARG CURL_VERSION=""
+ARG FINDUTILS_VERSION=""
+ARG CRYPTO_POLICIES_SCRIPTS_VERSION=""
 
 # Temurin JDK version
 ARG TEMURIN_JDK_VERSION=""
 
 # Python Module Versions
-ARG PYTHON_PIP_VERSION=""
 ARG PYTHON_SETUPTOOLS_VERSION=""
 
 # Confluent Docker Utils Version (Namely the tag or branch to grab from git to install)
@@ -76,6 +77,58 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 
 # This can be overriden for an offline/air-gapped builds
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
+
+# Install Python 3.14 from source FIRST
+RUN microdnf --nodocs -y install yum \
+    && yum --nodocs install -y --setopt=install_weak_deps=False \
+        gcc \
+        gcc-c++ \
+        make \
+        tar \
+        openssl-devel \
+        ca-certificates \
+        bzip2-devel \
+        libffi-devel \
+        zlib-devel \
+        sqlite-devel \
+        findutils \
+        python3-pip \
+    && python3 -m pip install --upgrade pip \
+    && python3 -m pip install sigstore \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m sigstore verify identity \
+        --bundle Python-${PYTHON314_VERSION}.tgz.sigstore \
+        --cert-identity hugo@python.org \
+        --cert-oidc-issuer https://github.com/login/oauth \
+        Python-${PYTHON314_VERSION}.tgz \
+    && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m pip uninstall -y sigstore \
+    && yum remove -y python3-pip \
+    && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
+    && tar -xzf Python-${PYTHON314_VERSION}.tgz \
+    && cd Python-${PYTHON314_VERSION} \
+    && ./configure --enable-optimizations \
+                   --with-ensurepip=install \
+                   --with-openssl=/usr \
+                   --with-openssl-rpath=auto \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-${PYTHON314_VERSION}* \
+    && rm -f /var/lib/alternatives/python /var/lib/alternatives/python3 /var/lib/alternatives/pip /var/lib/alternatives/pip3 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/python python /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.14 100 \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3.14 100 \
+    && python3 -c "import ssl; print('SSL module loaded successfully')" \
+    && python --version \
+    && python3 --version \
+    && pip --version \
+    && pip3 --version \
+    && yum remove -y gcc gcc-c++ make openssl-devel bzip2-devel libffi-devel zlib-devel sqlite-devel \
+    && yum clean all \
+    && rm -rf /tmp/* /root/.cache
 
 RUN printf "[temurin-jdk] \n\
 name=temurin-jdk \n\
@@ -92,8 +145,6 @@ RUN microdnf --nodocs -y install yum \
         "openssl${OPENSSL_VERSION}" \
         "wget${WGET_VERSION}" \
         "nmap-ncat${NETCAT_VERSION}" \
-        "python3${PYTHON39_VERSION}" \
-        "python3-pip${PYTHON_PIP_VERSION}" \
         "tar${TAR_VERSION}" \
         "procps-ng${PROCPS_VERSION}" \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
@@ -106,8 +157,6 @@ RUN microdnf --nodocs -y install yum \
         "findutils${FINDUTILS_VERSION}" \
         "crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION}" \
         "temurin-21-jdk${TEMURIN_JDK_VERSION}" \
-    && alternatives --install /usr/bin/python python /usr/bin/python3 2000 \
-    && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -132,7 +132,7 @@
                         <OPENSSL_VERSION>-${ubi9-minimal.openssl.version}</OPENSSL_VERSION>
                         <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                         <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                        <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                        <PYTHON314_VERSION>${python.python314.version}</PYTHON314_VERSION>
                         <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                         <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                         <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}</KRB5_WORKSTATION_VERSION>
@@ -141,9 +141,8 @@
                         <XZ_LIBS_VERSION>-${ubi9-minimal.xz-libs.version}</XZ_LIBS_VERSION>
                         <GLIBC_VERSION>-${ubi9-minimal.glibc.version}</GLIBC_VERSION>
                         <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
-                        <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi8-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
+                        <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                         <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                        <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
                         <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.tag}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                         <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
@@ -163,7 +162,7 @@
                                     <OPENSSL_VERSION>-${ubi9-minimal.openssl.version}</OPENSSL_VERSION>
                                     <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                                     <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                                    <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                                    <PYTHON314_VERSION>${python.python314.version}</PYTHON314_VERSION>
                                     <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                                     <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                                     <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}
@@ -175,7 +174,6 @@
                                     <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                                     <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                                    <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                                     <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}
                                     </PYTHON_SETUPTOOLS_VERSION>
                                     <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.162
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.169

--- a/base/tox.ini
+++ b/base/tox.ini
@@ -6,10 +6,10 @@ toxworkdir = /var/tmp
 deps =
     -rrequirements.txt
     flake8
-    pytest == 4.6.4
-    pytest-xdist == 1.29.0
-    pytest-cov == 2.7.1
-    sphinx!=1.2b2,<2.0.0
+    pytest ~= 8.0.0
+    pytest-xdist ~= 3.0.0
+    pytest-cov ~= 4.0.0
+    sphinx ~= 7.0.0
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
         <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.1</ubi9-minimal.python3.version>
         <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
         <ubi9-minimal.krb5-workstation.version>1.21.1-8.el9_6</ubi9-minimal.krb5-workstation.version>
@@ -90,7 +89,6 @@
         <ubi8-minimal.openssl.version>1.1.1k-15.el8_6</ubi8-minimal.openssl.version>
         <ubi8-minimal.wget.version>1.19.5-12.el8_10</ubi8-minimal.wget.version>
         <ubi8-minimal.nmap-ncat.version>7.92-2.el8_10</ubi8-minimal.nmap-ncat.version>
-        <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
         <ubi8-minimal.krb5-workstation.version>1.18.2-32.el8_10</ubi8-minimal.krb5-workstation.version>
@@ -102,13 +100,14 @@
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
         <ubi8-minimal.temurin-17-jdk.version>17.0.18.0.0.8-0</ubi8-minimal.temurin-17-jdk.version>
-        <ubi8-minimal.python39-pip.version>20.2.4-9.module+el8.10.0+21329+8d76b841</ubi8-minimal.python39-pip.version>
 
         <!-- Python Package Versions -->
+        <python.python314.version>3.14.3</python.python314.version>
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+
         <git-repo.cp-docker-utils.tag>v1.0.9</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: common-docker
 lang: python
-lang_version: 3.9
+lang_version: "3.14"
 git:
   enable: true
 semaphore:


### PR DESCRIPTION
## Summary
- Port Python 3.14 from-source build from PR #1321 (8.0.x) to 8.1.2-cp1
- Fixes cp-base-new Docker build failure caused by `python3-3.9.25-3.el9_7.1` RPM being removed from UBI9 repos
- Exact same changes as PR #1321, adapted for this branch

## Changes (10 files, matching PR #1321)
- `base/Dockerfile.ubi9` — Replace yum-installed python3 with Python 3.14 compiled from source
- `base/pom.xml` — PYTHON39_VERSION → PYTHON314_VERSION build args
- `pom.xml` — Remove stale python3/python39 version pins, add `python.python314.version=3.14.3`
- `.semaphore/cp_dockerfile_build.yml` — sem-version python 3.9 → 3.14
- `.semaphore/semaphore.yml` — sem-version python 3.9 → 3.14
- `base/requirements.txt` — confluent-docker-utils v0.0.162 → v0.0.169
- `base-java/requirements.txt` — confluent-docker-utils v0.0.162 → v0.0.169
- `base/tox.ini` — pytest/sphinx version bumps for Python 3.14 compatibility
- `base-java/tox.ini` — pytest/sphinx version bumps for Python 3.14 compatibility
- `service.yml` — lang_version 3.9 → 3.14

## Context
- The 8.1.2-cp1 branch was cut from 8.1.x before the Python 3.14 migration landed
- Red Hat removed python3-3.9.25-3.el9_7.1 from UBI9 repos, breaking the cp-base-new build
- PR #1493 (gzip dependency fix) may be needed as a followup if this build fails

## Test plan
- [ ] CI build passes on this branch
- [ ] cp-base-new Docker image builds successfully on both AMD and ARM