### PR TITLE
CPBR-3647 Cherry-pick docker dependency update for 8.1.2-cp1-rc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,15 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1774368033</ubi8-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1775152441</ubi8-minimal.image.version>
         <ubi9-micro.image.version>9.7-1773894938</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.7-1773939694</ubi9-minimal.image.version>
+        <ubi9-minimal.image.version>9.7-1775623882</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
 
         <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
         <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.1</ubi9-minimal.python3.version>
+        <ubi9-minimal.python3.version>3.9.25-3.el9_7.2</ubi9-minimal.python3.version>
         <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
         <ubi9-minimal.krb5-workstation.version>1.21.1-8.el9_6</ubi9-minimal.krb5-workstation.version>
@@ -109,10 +109,10 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>v1.0.9</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
-        <golang.image.version>1.26.1-trixie</golang.image.version>
+        <golang.image.version>1.26.2-trixie</golang.image.version>
 
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check


### PR DESCRIPTION
## Summary
Cherry-pick of commit `e3ec5c8cae7e754c112af1e5ebd4bfc063953b88` from 8.1.2-cp1 branch (PR #1518: Update Docker dependencies for 8.1.2-cp1).

We got the latest docker updates on 8.1.2 from https://semaphore.ci.confluent.io/workflows/701a0b72-e9a3-4f3c-aa76-04015a2c2059 docker dependency update job. Implementing the same changes through cherry-pick as the docker-dependencies-update Semaphore pipeline failed on RC build so not able to auto merge.

## Changes
- `ubi8-minimal.image.version`: `8.10-1774368033` → `8.10-1775152441`
- `ubi9-minimal.image.version`: `9.7-1773939694` → `9.7-1775623882`
- `ubi9-minimal.python3.version`: `3.9.25-3.el9_7.1` → `3.9.25-3.el9_7.2` (fixes `No match for argument` build failure)
- `git-repo.cp-docker-utils.tag`: `v1.0.9` → `v1.0.10`
- `golang.image.version`: `1.26.1-trixie` → `1.26.2-trixie`

