### PR TITLE
CPBR-3686 | Update base Docker images to JDK 25

### DIFF
--- a/base-java-micro/Dockerfile.ubi9
+++ b/base-java-micro/Dockerfile.ubi9
@@ -38,9 +38,9 @@ gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 
 RUN mkdir -p /microdir
 
-RUN echo "Installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \
+RUN echo "Installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
     && dnf install --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs -y \
-       temurin-21-jre${TEMURIN_JDK_VERSION} \
+       temurin-25-jre${TEMURIN_JDK_VERSION} \
        procps-ng${PROCPS_VERSION} \
        crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
        findutils${FINDUTILS_VERSION} \

--- a/base-java-micro/pom.xml
+++ b/base-java-micro/pom.xml
@@ -132,7 +132,7 @@
                                     <APP_GID>${app.gid}</APP_GID>
                                     <UBI_MICRO_VERSION>${ubi9-micro.image.version}</UBI_MICRO_VERSION>
                                     <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <PROCPS_VERSION>-${ubi9.procps-ng.version}</PROCPS_VERSION>
                                     <SKIP_SECURITY_UPDATE_CHECK>
                                         ${docker.skip-security-update-check}

--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -58,8 +58,8 @@ gpgcheck=1 \n\
 gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
-RUN echo "installing temurin-21-jre:${TEMURIN_JDK_VERSION}" \
-    && microdnf install -y temurin-21-jre${TEMURIN_JDK_VERSION} \
+RUN echo "installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
+    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
     && microdnf install -y procps-ng${PROCPS_VERSION} \
     && microdnf install -y crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
     && microdnf install -y findutils${FINDUTILS_VERSION} \

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -130,7 +130,7 @@
                             <build>
                                 <args>
                                     <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                                     <SKIP_SECURITY_UPDATE_CHECK>
                                         ${docker.skip-security-update-check}

--- a/base-lite/Dockerfile.ubi9
+++ b/base-lite/Dockerfile.ubi9
@@ -73,7 +73,7 @@ gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 RUN microdnf --nodocs -y install yum \
     && yum --nodocs update -y \
     && yum --nodocs install -y --setopt=install_weak_deps=False \
-        "temurin-21-jre${TEMURIN_JDK_VERSION}" \
+        "temurin-25-jre${TEMURIN_JDK_VERSION}" \
     && microdnf clean all \
     && yum clean all \
     && rm -rf /tmp/* \

--- a/base-lite/pom.xml
+++ b/base-lite/pom.xml
@@ -89,7 +89,7 @@
                             <build>
                                 <args>
                                     <UBI_MINIMAL_VERSION>${ubi9-minimal.image.version}</UBI_MINIMAL_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <SKIP_SECURITY_UPDATE_CHECK>
                                         ${docker.skip-security-update-check}
                                     </SKIP_SECURITY_UPDATE_CHECK>

--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -157,7 +157,7 @@ RUN microdnf --nodocs -y install yum \
         "glibc-minimal-langpack${GLIBC_VERSION}" \
         "findutils${FINDUTILS_VERSION}" \
         "crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION}" \
-        "temurin-21-jdk${TEMURIN_JDK_VERSION}" \
+        "temurin-25-jdk${TEMURIN_JDK_VERSION}" \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && yum remove -y git \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -145,7 +145,7 @@
                                     <GLIBC_VERSION>-${ubi9-minimal.glibc.version}</GLIBC_VERSION>
                                     <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                                     <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
-                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
+                                    <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-25-jdk.version}</TEMURIN_JDK_VERSION>
                                     <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}
                                     </PYTHON_SETUPTOOLS_VERSION>
                                     <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <ubi9-micro.image.version>9.7-1773894938</ubi9-micro.image.version>
         <ubi9-minimal.image.version>9.7-1776833838</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
-        <ubi9.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9.temurin-21-jdk.version>
+        <ubi9.temurin-25-jdk.version>25.0.2.0.0.10-0</ubi9.temurin-25-jdk.version>
         <ubi9.procps-ng.version>3.3.17-14.el9</ubi9.procps-ng.version>
         <ubi9.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9.crypto-policies-scripts.version>
         <ubi9.findutils.version>4.8.0-7.el9</ubi9.findutils.version>
@@ -101,7 +101,7 @@
         <ubi9-minimal.glibc.version>2.34-231.el9_7.10</ubi9-minimal.glibc.version>
         <ubi9-minimal.findutils.version>4.8.0-7.el9</ubi9-minimal.findutils.version>
         <ubi9-minimal.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9-minimal.crypto-policies-scripts.version>
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9-minimal.temurin-25-jdk.version>25.0.2.0.0.10-0</ubi9-minimal.temurin-25-jdk.version>
         <ubi9-minimal.python3-pip.version>21.3.1-1.el9</ubi9-minimal.python3-pip.version>
 
         <ubi8-minimal.openssl.version>1.1.1k-15.el8_6</ubi8-minimal.openssl.version>


### PR DESCRIPTION
### Change Description
AK added JDK 25 support in 4.2. This PR updates all four base images (cp-base-java, cp-base-java-micro, cp-base-new, cp-base-lite) to JDK 25.

### Changes Made

- Updated root and module level pom.xml version properties to temurin 25 jdk
- Updated each dockerfiles to install temurin 25
- Added the jdk version pinning after verifying the version in adoptium repo on ubi9 container on local

### Testing
<img width="1722" height="410" alt="image" src="https://github.com/user-attachments/assets/5a9ff64e-acc8-461a-b18d-52b56f593310" />

https://confluentinc.atlassian.net/browse/CPBR-3686
