### PR TITLE
CPBR-3749: bump confluent-docker-utils to v0.0.170 (CVE-2026-25645)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.170</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.2-trixie</golang.image.version>


### PR DESCRIPTION
Updating `confluent-docker-utils` to `v0.0.170` to resolve **CVE-2026-25645**.

`v0.0.170` ships `requests~=2.33.0`, replacing `requests~=2.32.0` (which resolved to `2.32.5` and was flagged in `cp-base-new` and downstream `cp-jmxterm` images).

Upstream fix: confluentinc/confluent-docker-utils#222 (merged, tag `v0.0.170` published).

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749