### PR TITLE
CPBR-3749: upgrade cp-base-new to Python 3.14 + bump docker-utils v0.0.170 (CVE-2026-25645)

### DIFF
--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -55,7 +55,7 @@ ARG OPENSSL_VERSION=""
 ARG OPENSSL_LIBS_VERSION=""
 ARG WGET_VERSION=""
 ARG NETCAT_VERSION=""
-ARG PYTHON39_VERSION=""
+ARG PYTHON314_VERSION=""
 ARG TAR_VERSION=""
 ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
@@ -64,12 +64,13 @@ ARG HOSTNAME_VERSION=""
 ARG XZ_LIBS_VERSION=""
 ARG GLIBC_VERSION=""
 ARG CURL_VERSION=""
+ARG FINDUTILS_VERSION=""
+ARG CRYPTO_POLICIES_SCRIPTS_VERSION=""
 
 # Temurin JDK version
 ARG TEMURIN_JDK_VERSION=""
 
 # Python Module Versions
-ARG PYTHON_PIP_VERSION=""
 ARG PYTHON_SETUPTOOLS_VERSION=""
 
 # Confluent Docker Utils Version (Namely the tag or branch to grab from git to install)
@@ -77,6 +78,59 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 
 # This can be overriden for an offline/air-gapped builds
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
+
+# Install Python 3.14 from source FIRST (required for requests>=2.33 / CVE-2026-25645 fix)
+RUN microdnf --nodocs -y install yum \
+    && yum --nodocs install -y --setopt=install_weak_deps=False \
+        gcc \
+        gcc-c++ \
+        make \
+        tar \
+        gzip \
+        openssl-devel \
+        ca-certificates \
+        bzip2-devel \
+        libffi-devel \
+        zlib-devel \
+        sqlite-devel \
+        findutils \
+        python3-pip \
+    && python3 -m pip install --upgrade pip \
+    && python3 -m pip install sigstore \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m sigstore verify identity \
+        --bundle Python-${PYTHON314_VERSION}.tgz.sigstore \
+        --cert-identity hugo@python.org \
+        --cert-oidc-issuer https://github.com/login/oauth \
+        Python-${PYTHON314_VERSION}.tgz \
+    && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m pip uninstall -y sigstore \
+    && yum remove -y python3-pip \
+    && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
+    && tar -xzf Python-${PYTHON314_VERSION}.tgz \
+    && cd Python-${PYTHON314_VERSION} \
+    && ./configure --enable-optimizations \
+                   --with-ensurepip=install \
+                   --with-openssl=/usr \
+                   --with-openssl-rpath=auto \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-${PYTHON314_VERSION}* \
+    && rm -f /var/lib/alternatives/python /var/lib/alternatives/python3 /var/lib/alternatives/pip /var/lib/alternatives/pip3 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/python python /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.14 100 \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3.14 100 \
+    && python3 -c "import ssl; print('SSL module loaded successfully')" \
+    && python --version \
+    && python3 --version \
+    && pip --version \
+    && pip3 --version \
+    && yum remove -y gcc gcc-c++ make openssl-devel bzip2-devel libffi-devel zlib-devel sqlite-devel \
+    && yum clean all \
+    && rm -rf /tmp/* /root/.cache
 
 RUN printf "[temurin-jdk] \n\
 name=temurin-jdk \n\
@@ -86,13 +140,14 @@ gpgcheck=1 \n\
 gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
 " > /etc/yum.repos.d/adoptium.repo
 
-RUN microdnf --nodocs -y install \
-        yum \
+RUN microdnf --nodocs -y install yum \
+    && yum --nodocs update -y \
+    && yum --nodocs install -y --setopt=install_weak_deps=False \
         git \
+        "openssl${OPENSSL_VERSION}" \
+        "openssl-libs${OPENSSL_LIBS_VERSION}" \
         "wget${WGET_VERSION}" \
         "nmap-ncat${NETCAT_VERSION}" \
-        "python3${PYTHON39_VERSION}" \
-        "python3-pip${PYTHON_PIP_VERSION}" \
         "tar${TAR_VERSION}" \
         "procps-ng${PROCPS_VERSION}" \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
@@ -105,14 +160,11 @@ RUN microdnf --nodocs -y install \
         "findutils${FINDUTILS_VERSION}" \
         "crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION}" \
         "temurin-21-jdk${TEMURIN_JDK_VERSION}" \
-        "openssl${OPENSSL_VERSION}" \
-        "openssl-libs${OPENSSL_LIBS_VERSION}" \
     && microdnf reinstall -y openssl-libs \
-    && alternatives --install /usr/bin/python python /usr/bin/python3 2000 \
-    && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
-    && microdnf clean all \
+    && yum remove -y git \
+    && yum clean all \
     && rm -rf /tmp/* \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && useradd --no-log-init --create-home --shell /bin/bash appuser \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -133,7 +133,7 @@
                         <OPENSSL_LIBS_VERSION>-${ubi9-minimal.openssl-libs.version}</OPENSSL_LIBS_VERSION>
                         <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                         <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                        <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                        <PYTHON314_VERSION>${python-runtime.3-14.version}</PYTHON314_VERSION>
                         <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                         <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                         <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}</KRB5_WORKSTATION_VERSION>
@@ -144,7 +144,6 @@
                         <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                         <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                         <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                        <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
                         <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.tag}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                         <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
@@ -165,7 +164,7 @@
                                     <OPENSSL_LIBS_VERSION>-${ubi9-minimal.openssl-libs.version}</OPENSSL_LIBS_VERSION>
                                     <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                                     <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                                    <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                                    <PYTHON314_VERSION>${python-runtime.3-14.version}</PYTHON314_VERSION>
                                     <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                                     <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                                     <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}
@@ -177,7 +176,6 @@
                                     <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                                     <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                                    <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                                     <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}
                                     </PYTHON_SETUPTOOLS_VERSION>
                                     <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -107,11 +107,14 @@
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
         <ubi8-minimal.python39-pip.version>20.2.4-9.module+el8.10.0+21329+8d76b841</ubi8-minimal.python39-pip.version>
 
-        <!-- Python Package Versions -->
+        <!-- Python Runtime Versions -->
+        <python-runtime.3-14.version>3.14.4</python-runtime.3-14.version>
+
+        <!-- PyPI Package Versions -->
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.170</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.2-trixie</golang.image.version>


### PR DESCRIPTION
## Summary

Fix CVE-2026-25645 in `cp-base-new` (and downstream `cp-jmxterm`) on the FedRAMP `8.0.2-cp7` branch.

The CVE fix is in `requests==2.33.0`, which **requires Python ≥ 3.10**. cp-base-new on 8.0.2-cp7 currently ships **Python 3.9.25**, so a docker-utils-only bump to v0.0.170 (PR #1654) failed at the pip install step:

```
ERROR: Could not find a version that satisfies the requirement requests~=2.33.0
       (from versions: …, 2.32.4, 2.32.5)
```

This PR ports the **Python 3.14 from-source build** (sigstore-verified) from active development branch `8.0.x` (and `8.1.x`, which are identical for these files) onto `8.0.2-cp7`, while preserving cp7's FedRAMP-specific FIPS bits (OPENSSL_LIBS_VERSION arg + `microdnf reinstall -y openssl-libs` + `update-crypto-policies --set FIPS` + openssl-fips.cnf).

## Changes

- `pom.xml`
  - Add `<python-runtime.3-14.version>3.14.4</…>` (matches 8.0.x / 8.1.x / master)
  - Bump `<git-repo.confluent-docker-utils.tag>` v0.0.169 → **v0.0.170** (carries `requests~=2.33.0`)
- `base/pom.xml`
  - Swap `PYTHON39_VERSION` → `PYTHON314_VERSION` build arg (using `${python-runtime.3-14.version}`) in both `dockerfile-maven-plugin` and `fabric8/docker-maven-plugin` blocks
  - Remove `PYTHON_PIP_VERSION` build arg (Python 3.14 source compile bundles pip)
- `base/Dockerfile.ubi9`
  - Replace `microdnf install python3 + python3-pip` with **Python 3.14 source compile** + sigstore tarball verification
  - Set `update-alternatives` for python/python3/pip/pip3 → /usr/local/bin/python3.14
  - **Preserve FIPS bits**: `OPENSSL_LIBS_VERSION` arg, `openssl-libs` install, `microdnf reinstall -y openssl-libs`, `update-crypto-policies --set FIPS`, `COPY openssl-fips.cnf`

## Reference

- confluent-docker-utils #222 — bumped `requests~=2.33.0`, tag `v0.0.170` published
- common-docker #1280 (CPBR-3030) — original Python 3.14 source build for `Dockerfile.ubi8` on 7.4.x
- common-docker merge commit `2119e4d7` — adapted Python 3.14 to `Dockerfile.ubi9` on 8.0.x
- This PR replaces #1654 (which only bumped the docker-utils tag and was blocked by Python 3.9 floor)

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749

> ⚠️ **First Python upgrade ever applied to a `-cp*` FedRAMP hotfix branch in this repo.** Survey of all `-cp` / `-post` / `-hotfix` branches shows none have moved off Python 3.9 before. Recommend FedRAMP/security review.