### PR TITLE
CCDB-4523: Strip config.providers from kafka-ready preflight check

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -222,6 +222,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -222,13 +222,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -23,17 +23,13 @@ import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import io.confluent.admin.utils.ClusterStatus;
 
@@ -59,23 +55,11 @@ public class KafkaReadyCommand {
   public static final String KAFKA_READY = "kafka-ready";
   private static final String CONFIG_PROVIDERS_PREFIX = "config.providers";
 
-  @FunctionalInterface
-  interface KafkaReadyChecker {
-    boolean isReady(Map<String, String> config, int minBrokerCount, int timeoutMs);
-  }
-
-  // Matches Kafka config provider variable syntax: ${provider-name:path[:key]}
-  // Requires at least one colon separator to distinguish from other ${...} placeholders.
-  private static final Pattern CONFIG_PROVIDER_VAR_PATTERN =
-      Pattern.compile("\\$\\{[^:}]+:[^}]+}");
-
-  // Property key prefixes that affect Kafka client connectivity. Only these are checked
-  // for unresolved config provider variable references when deciding whether to skip
-  // the kafka-ready check. Non-client keys (e.g. connector configs) are irrelevant
-  // since AdminClient ignores them.
-  private static final String[] KAFKA_CLIENT_KEY_PREFIXES = {
-      "security.", "sasl.", "ssl.", "bootstrap.servers"
-  };
+  // When set to "true", config.providers entries are stripped from the worker config
+  // before running the kafka-ready check. This prevents ClassNotFoundException when
+  // config provider plugin JARs are on the worker's plugin.path but not on the
+  // CUB_CLASSPATH used by kafka-ready. Default: disabled (original behavior).
+  static final String SKIP_CONFIG_PROVIDERS_ENV = "CUB_KAFKA_READY_SKIP_CONFIG_PROVIDERS";
 
   private static ArgumentParser createArgsParser() {
     ArgumentParser kafkaReady = ArgumentParsers
@@ -154,7 +138,12 @@ public class KafkaReadyCommand {
               "Bootstrap servers should be provided through config or bootstrap_servers"
           );
         }
-        success = checkKafkaReadyWithConfigProviderResilience(
+
+        if (isConfigProviderResilienceEnabled()) {
+          workerProps = stripConfigProviders(workerProps);
+        }
+
+        success = ClusterStatus.isKafkaReady(
             workerProps,
             res.getInt("min_expected_brokers"),
             res.getInt("timeout")
@@ -182,137 +171,28 @@ public class KafkaReadyCommand {
   }
 
   /**
-   * Attempts the kafka-ready check, handling config provider class loading failures gracefully.
-   *
-   * <p>Strategy:
-   * 0. If no config.providers entries are present, run the check directly (fast path).
-   * 1. Try with the full config (config providers may be loadable if on the classpath).
-   * 2. If config provider class loading fails (ConfigException wrapping ClassNotFoundException),
-   *    strip config.providers entries from a copy and check for unresolved variable references
-   *    in Kafka client connectivity properties (security.*, sasl.*, ssl.*).
-   * 3. If client connectivity properties contain unresolved ${provider:path:key} references,
-   *    skip the check with a warning - the Connect worker will verify connectivity on startup.
-   * 4. Otherwise, retry the check with the stripped copy (without config.providers).
-   *
-   * <p>The caller's workerProps map is never mutated.
+   * Returns a copy of the properties map with config.providers entries removed.
+   * If no config.providers entries are found, returns the original map.
    */
-  static boolean checkKafkaReadyWithConfigProviderResilience(
-      Map<String, String> workerProps,
-      int minBrokerCount,
-      int timeoutMs
-  ) {
-    return checkKafkaReadyWithConfigProviderResilience(
-        workerProps, minBrokerCount, timeoutMs, ClusterStatus::isKafkaReady);
-  }
-
-  static boolean checkKafkaReadyWithConfigProviderResilience(
-      Map<String, String> workerProps,
-      int minBrokerCount,
-      int timeoutMs,
-      KafkaReadyChecker checker
-  ) {
-    if (!hasConfigProviders(workerProps)) {
-      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
+  static Map<String, String> stripConfigProviders(Map<String, String> props) {
+    if (!props.containsKey(CONFIG_PROVIDERS_PREFIX)) {
+      return props;
     }
 
-    try {
-      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
-    } catch (ConfigException e) {
-      if (!isConfigProviderLoadFailure(e)) {
-        throw e;
-      }
-      log.warn("Config provider class could not be loaded during kafka-ready check: {}",
-          e.getMessage(), e);
-
-      Map<String, String> strippedProps = new HashMap<>(workerProps);
-      stripConfigProviders(strippedProps);
-
-      List<String> unresolvedKeys = findUnresolvedConfigProviderVars(strippedProps);
-      if (!unresolvedKeys.isEmpty()) {
-        log.warn("Skipping kafka-ready check - the following properties contain unresolved "
-            + "config provider variable references that cannot be resolved without the "
-            + "config provider plugin: {}. The Connect worker will verify broker connectivity "
-            + "on startup.", unresolvedKeys);
-        return true;
-      }
-
-      log.warn("Retrying kafka-ready check without config provider properties.");
-      return checker.isReady(strippedProps, minBrokerCount, timeoutMs);
-    }
-  }
-
-  /**
-   * Returns true if the properties map contains config.providers entries.
-   */
-  static boolean hasConfigProviders(Map<String, String> props) {
-    return props.containsKey(CONFIG_PROVIDERS_PREFIX);
-  }
-
-  /**
-   * Returns true if the exception is a ConfigException specifically caused by a config
-   * provider class loading failure. Requires both:
-   * - The exception message references "config.providers" (to distinguish from SASL/SSL
-   *   handler class loading failures which also throw ConfigException with CNFE)
-   * - Either a ClassNotFoundException/NoClassDefFoundError in the cause chain, or
-   *   "Could not load" in the message (fallback for truncated cause chains)
-   */
-  static boolean isConfigProviderLoadFailure(ConfigException e) {
-    String msg = e.getMessage();
-    boolean mentionsConfigProviders = msg != null && msg.contains("config.providers");
-    if (!mentionsConfigProviders) {
-      return false;
-    }
-
-    Throwable cause = e.getCause();
-    while (cause != null) {
-      if (cause instanceof ClassNotFoundException || cause instanceof NoClassDefFoundError) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    // Fallback: message-only check when cause chain is truncated
-    return msg.contains("Could not load");
-  }
-
-  /**
-   * Removes config.providers entries from the properties map.
-   */
-  static void stripConfigProviders(Map<String, String> props) {
-    List<String> removed = new java.util.ArrayList<>();
-    Iterator<Map.Entry<String, String>> it = props.entrySet().iterator();
+    Map<String, String> result = new HashMap<>(props);
+    Iterator<String> it = result.keySet().iterator();
     while (it.hasNext()) {
-      String key = it.next().getKey();
+      String key = it.next();
       if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
-        removed.add(key);
+        log.warn("Stripping property '{}' from kafka-ready config "
+            + "({}=true).", key, SKIP_CONFIG_PROVIDERS_ENV);
         it.remove();
       }
     }
-    if (!removed.isEmpty()) {
-      log.warn("Removed {} config provider properties from kafka-ready config: {}",
-          removed.size(), removed);
-    }
+    return result;
   }
 
-  /**
-   * Returns Kafka client connectivity property keys whose values contain unresolved
-   * config provider variable references (e.g. ${secretmanager:path:key}). Only checks
-   * keys that affect broker connectivity (security.*, sasl.*, ssl.*, bootstrap.servers)
-   * since non-client keys are ignored by AdminClient and won't cause failures.
-   */
-  static List<String> findUnresolvedConfigProviderVars(Map<String, String> props) {
-    return props.entrySet().stream()
-        .filter(e -> isKafkaClientKey(e.getKey()))
-        .filter(e -> CONFIG_PROVIDER_VAR_PATTERN.matcher(e.getValue()).find())
-        .map(Map.Entry::getKey)
-        .collect(Collectors.toList());
-  }
-
-  private static boolean isKafkaClientKey(String key) {
-    for (String prefix : KAFKA_CLIENT_KEY_PREFIXES) {
-      if (key.startsWith(prefix)) {
-        return true;
-      }
-    }
-    return false;
+  static boolean isConfigProviderResilienceEnabled() {
+    return "true".equalsIgnoreCase(System.getenv(SKIP_CONFIG_PROVIDERS_ENV));
   }
 }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -177,7 +177,7 @@ public class KafkaReadyCommand {
   static Map<String, String> stripConfigProviders(Map<String, String> props) {
     boolean hasProviderKeys = false;
     for (String key : props.keySet()) {
-      if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
+      if (key.startsWith(CONFIG_PROVIDERS_PREFIX)) {
         hasProviderKeys = true;
         break;
       }
@@ -191,7 +191,7 @@ public class KafkaReadyCommand {
     Iterator<String> it = result.keySet().iterator();
     while (it.hasNext()) {
       String key = it.next();
-      if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
+      if (key.startsWith(CONFIG_PROVIDERS_PREFIX)) {
         it.remove();
         count++;
       }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -139,7 +139,7 @@ public class KafkaReadyCommand {
           );
         }
 
-        if (isConfigProviderResilienceEnabled()) {
+        if (isSkipConfigProvidersEnabled()) {
           workerProps = stripConfigProviders(workerProps);
         }
 
@@ -172,27 +172,36 @@ public class KafkaReadyCommand {
 
   /**
    * Returns a copy of the properties map with config.providers entries removed.
-   * If no config.providers entries are found, returns the original map.
+   * If no config.providers entries are found, returns the original map unmodified.
    */
   static Map<String, String> stripConfigProviders(Map<String, String> props) {
-    if (!props.containsKey(CONFIG_PROVIDERS_PREFIX)) {
+    boolean hasProviderKeys = false;
+    for (String key : props.keySet()) {
+      if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
+        hasProviderKeys = true;
+        break;
+      }
+    }
+    if (!hasProviderKeys) {
       return props;
     }
 
     Map<String, String> result = new HashMap<>(props);
+    int count = 0;
     Iterator<String> it = result.keySet().iterator();
     while (it.hasNext()) {
       String key = it.next();
       if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
-        log.warn("Stripping property '{}' from kafka-ready config "
-            + "({}=true).", key, SKIP_CONFIG_PROVIDERS_ENV);
         it.remove();
+        count++;
       }
     }
+    log.info("Stripped {} config.providers properties from kafka-ready config ({}=true).",
+        count, SKIP_CONFIG_PROVIDERS_ENV);
     return result;
   }
 
-  static boolean isConfigProviderResilienceEnabled() {
+  static boolean isSkipConfigProvidersEnabled() {
     return "true".equalsIgnoreCase(System.getenv(SKIP_CONFIG_PROVIDERS_ENV));
   }
 }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -69,6 +69,14 @@ public class KafkaReadyCommand {
   private static final Pattern CONFIG_PROVIDER_VAR_PATTERN =
       Pattern.compile("\\$\\{[^:}]+:[^}]+}");
 
+  // Property key prefixes that affect Kafka client connectivity. Only these are checked
+  // for unresolved config provider variable references when deciding whether to skip
+  // the kafka-ready check. Non-client keys (e.g. connector configs) are irrelevant
+  // since AdminClient ignores them.
+  private static final String[] KAFKA_CLIENT_KEY_PREFIXES = {
+      "security.", "sasl.", "ssl.", "bootstrap.servers"
+  };
+
   private static ArgumentParser createArgsParser() {
     ArgumentParser kafkaReady = ArgumentParsers
         .newArgumentParser(KAFKA_READY)
@@ -282,13 +290,25 @@ public class KafkaReadyCommand {
   }
 
   /**
-   * Returns property keys whose values contain unresolved config provider variable
-   * references (e.g. ${secretmanager:path:key}).
+   * Returns Kafka client connectivity property keys whose values contain unresolved
+   * config provider variable references (e.g. ${secretmanager:path:key}). Only checks
+   * keys that affect broker connectivity (security.*, sasl.*, ssl.*, bootstrap.servers)
+   * since non-client keys are ignored by AdminClient and won't cause failures.
    */
   static List<String> findUnresolvedConfigProviderVars(Map<String, String> props) {
     return props.entrySet().stream()
+        .filter(e -> isKafkaClientKey(e.getKey()))
         .filter(e -> CONFIG_PROVIDER_VAR_PATTERN.matcher(e.getValue()).find())
         .map(Map.Entry::getKey)
         .collect(Collectors.toList());
+  }
+
+  private static boolean isKafkaClientKey(String key) {
+    for (String prefix : KAFKA_CLIENT_KEY_PREFIXES) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -29,7 +29,12 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.config.ConfigException;
 
 import io.confluent.admin.utils.ClusterStatus;
 
@@ -54,6 +59,8 @@ public class KafkaReadyCommand {
   private static final Logger log = LogManager.getLogger(KafkaReadyCommand.class);
   public static final String KAFKA_READY = "kafka-ready";
   private static final String CONFIG_PROVIDERS_PREFIX = "config.providers";
+  // Matches Kafka config provider variable syntax: ${provider-name:path:key}
+  private static final Pattern CONFIG_PROVIDER_VAR_PATTERN = Pattern.compile("\\$\\{[^}]+}");
 
   private static ArgumentParser createArgsParser() {
     ArgumentParser kafkaReady = ArgumentParsers
@@ -120,7 +127,6 @@ public class KafkaReadyCommand {
       } else {
         if (res.getString("config") != null) {
           workerProps = Utils.propsToStringMap(Utils.loadProps(res.getString("config")));
-          stripConfigProviders(workerProps);
         }
         if (res.getString("bootstrap_servers") != null) {
           workerProps.put(
@@ -133,7 +139,7 @@ public class KafkaReadyCommand {
               "Bootstrap servers should be provided through config or bootstrap_servers"
           );
         }
-        success = ClusterStatus.isKafkaReady(
+        success = checkKafkaReadyWithConfigProviderResilience(
             workerProps,
             res.getInt("min_expected_brokers"),
             res.getInt("timeout")
@@ -161,30 +167,89 @@ public class KafkaReadyCommand {
   }
 
   /**
-   * Removes config.providers entries from the properties map. These entries cause
-   * ClassNotFoundException during AdminClient creation when the config provider
-   * plugin JARs are not on the kafka-ready classpath (they live on the worker's
-   * plugin.path instead). The kafka-ready preflight check does not need config
-   * providers, so stripping them is safe.
+   * Attempts the kafka-ready check, handling config provider class loading failures gracefully.
+   *
+   * <p>Strategy:
+   * 1. Try with the full config (config providers may be loadable if on the classpath).
+   * 2. If config provider class loading fails (ConfigException wrapping ClassNotFoundException),
+   *    strip config.providers entries and check for unresolved variable references.
+   * 3. If remaining properties contain unresolved ${provider:...} references (i.e. security
+   *    properties depend on config providers), skip the check with a warning — the Connect
+   *    worker will verify connectivity itself on startup.
+   * 4. Otherwise, retry the check without config.providers.
+   */
+  static boolean checkKafkaReadyWithConfigProviderResilience(
+      Map<String, String> workerProps,
+      int minBrokerCount,
+      int timeoutMs
+  ) {
+    if (!hasConfigProviders(workerProps)) {
+      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+    }
+
+    try {
+      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+    } catch (ConfigException e) {
+      if (!isConfigProviderLoadFailure(e)) {
+        throw e;
+      }
+      log.warn("Config provider class could not be loaded during kafka-ready check: {}",
+          e.getMessage());
+
+      stripConfigProviders(workerProps);
+
+      List<String> unresolvedKeys = findUnresolvedConfigProviderVars(workerProps);
+      if (!unresolvedKeys.isEmpty()) {
+        log.warn("Skipping kafka-ready check — the following properties contain unresolved "
+            + "config provider variable references that cannot be resolved without the "
+            + "config provider plugin: {}. The Connect worker will verify broker connectivity "
+            + "on startup.", unresolvedKeys);
+        return true;
+      }
+
+      log.warn("Retrying kafka-ready check without config provider properties.");
+      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+    }
+  }
+
+  /**
+   * Returns true if the properties map contains config.providers entries.
+   */
+  static boolean hasConfigProviders(Map<String, String> props) {
+    return props.containsKey(CONFIG_PROVIDERS_PREFIX);
+  }
+
+  /**
+   * Returns true if the exception is a ConfigException caused by a config provider
+   * class loading failure.
+   */
+  static boolean isConfigProviderLoadFailure(ConfigException e) {
+    String msg = e.getMessage();
+    return msg != null && msg.contains("config.providers") && msg.contains("Could not load");
+  }
+
+  /**
+   * Removes config.providers entries from the properties map.
    */
   static void stripConfigProviders(Map<String, String> props) {
     Iterator<Map.Entry<String, String>> it = props.entrySet().iterator();
-    boolean found = false;
     while (it.hasNext()) {
       String key = it.next().getKey();
       if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
-        log.warn("Removing property '{}' from kafka-ready config — config provider classes "
-            + "are not needed for the preflight broker connectivity check and may not be on "
-            + "the classpath.", key);
+        log.warn("Removing property '{}' from kafka-ready config.", key);
         it.remove();
-        found = true;
       }
     }
-    if (found) {
-      log.warn("Config provider properties were stripped from the kafka-ready check. "
-          + "If your Connect worker config uses config providers to resolve security "
-          + "properties (e.g. passwords from a secrets manager), ensure those values are "
-          + "also available as literal values or environment variables for the preflight check.");
-    }
+  }
+
+  /**
+   * Returns property keys whose values contain unresolved config provider variable
+   * references (e.g. ${secretmanager:path:key}).
+   */
+  static List<String> findUnresolvedConfigProviderVars(Map<String, String> props) {
+    return props.entrySet().stream()
+        .filter(e -> CONFIG_PROVIDER_VAR_PATTERN.matcher(e.getValue()).find())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toList());
   }
 }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -59,8 +59,10 @@ public class KafkaReadyCommand {
   private static final Logger log = LogManager.getLogger(KafkaReadyCommand.class);
   public static final String KAFKA_READY = "kafka-ready";
   private static final String CONFIG_PROVIDERS_PREFIX = "config.providers";
-  // Matches Kafka config provider variable syntax: ${provider-name:path:key}
-  private static final Pattern CONFIG_PROVIDER_VAR_PATTERN = Pattern.compile("\\$\\{[^}]+}");
+  // Matches Kafka config provider variable syntax: ${provider-name:path[:key]}
+  // Requires at least one colon separator to distinguish from other ${...} placeholders.
+  private static final Pattern CONFIG_PROVIDER_VAR_PATTERN =
+      Pattern.compile("\\$\\{[^:}]+:[^}]+}");
 
   private static ArgumentParser createArgsParser() {
     ArgumentParser kafkaReady = ArgumentParsers
@@ -221,9 +223,18 @@ public class KafkaReadyCommand {
 
   /**
    * Returns true if the exception is a ConfigException caused by a config provider
-   * class loading failure.
+   * class loading failure. Checks both the cause chain for ClassNotFoundException /
+   * NoClassDefFoundError and the message for config.providers references as a fallback.
    */
   static boolean isConfigProviderLoadFailure(ConfigException e) {
+    Throwable cause = e.getCause();
+    while (cause != null) {
+      if (cause instanceof ClassNotFoundException || cause instanceof NoClassDefFoundError) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    // Fallback: check message in case the cause chain is truncated
     String msg = e.getMessage();
     return msg != null && msg.contains("config.providers") && msg.contains("Could not load");
   }

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -23,6 +23,7 @@ import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.apache.kafka.common.config.ConfigException;
 
 import io.confluent.admin.utils.ClusterStatus;
 
@@ -238,11 +237,20 @@ public class KafkaReadyCommand {
   }
 
   /**
-   * Returns true if the exception is a ConfigException caused by a config provider
-   * class loading failure. Checks both the cause chain for ClassNotFoundException /
-   * NoClassDefFoundError and the message for config.providers references as a fallback.
+   * Returns true if the exception is a ConfigException specifically caused by a config
+   * provider class loading failure. Requires both:
+   * - The exception message references "config.providers" (to distinguish from SASL/SSL
+   *   handler class loading failures which also throw ConfigException with CNFE)
+   * - Either a ClassNotFoundException/NoClassDefFoundError in the cause chain, or
+   *   "Could not load" in the message (fallback for truncated cause chains)
    */
   static boolean isConfigProviderLoadFailure(ConfigException e) {
+    String msg = e.getMessage();
+    boolean mentionsConfigProviders = msg != null && msg.contains("config.providers");
+    if (!mentionsConfigProviders) {
+      return false;
+    }
+
     Throwable cause = e.getCause();
     while (cause != null) {
       if (cause instanceof ClassNotFoundException || cause instanceof NoClassDefFoundError) {
@@ -250,9 +258,8 @@ public class KafkaReadyCommand {
       }
       cause = cause.getCause();
     }
-    // Fallback: check message in case the cause chain is truncated
-    String msg = e.getMessage();
-    return msg != null && msg.contains("config.providers") && msg.contains("Could not load");
+    // Fallback: message-only check when cause chain is truncated
+    return msg.contains("Could not load");
   }
 
   /**

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -194,13 +194,13 @@ public class KafkaReadyCommand {
         throw e;
       }
       log.warn("Config provider class could not be loaded during kafka-ready check: {}",
-          e.getMessage());
+          e.getMessage(), e);
 
       stripConfigProviders(workerProps);
 
       List<String> unresolvedKeys = findUnresolvedConfigProviderVars(workerProps);
       if (!unresolvedKeys.isEmpty()) {
-        log.warn("Skipping kafka-ready check — the following properties contain unresolved "
+        log.warn("Skipping kafka-ready check - the following properties contain unresolved "
             + "config provider variable references that cannot be resolved without the "
             + "config provider plugin: {}. The Connect worker will verify broker connectivity "
             + "on startup.", unresolvedKeys);
@@ -232,13 +232,18 @@ public class KafkaReadyCommand {
    * Removes config.providers entries from the properties map.
    */
   static void stripConfigProviders(Map<String, String> props) {
+    List<String> removed = new java.util.ArrayList<>();
     Iterator<Map.Entry<String, String>> it = props.entrySet().iterator();
     while (it.hasNext()) {
       String key = it.next().getKey();
       if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
-        log.warn("Removing property '{}' from kafka-ready config.", key);
+        removed.add(key);
         it.remove();
       }
+    }
+    if (!removed.isEmpty()) {
+      log.warn("Removed {} config provider properties from kafka-ready config: {}",
+          removed.size(), removed);
     }
   }
 

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -59,6 +59,12 @@ public class KafkaReadyCommand {
   private static final Logger log = LogManager.getLogger(KafkaReadyCommand.class);
   public static final String KAFKA_READY = "kafka-ready";
   private static final String CONFIG_PROVIDERS_PREFIX = "config.providers";
+
+  @FunctionalInterface
+  interface KafkaReadyChecker {
+    boolean isReady(Map<String, String> config, int minBrokerCount, int timeoutMs);
+  }
+
   // Matches Kafka config provider variable syntax: ${provider-name:path[:key]}
   // Requires at least one colon separator to distinguish from other ${...} placeholders.
   private static final Pattern CONFIG_PROVIDER_VAR_PATTERN =
@@ -185,12 +191,22 @@ public class KafkaReadyCommand {
       int minBrokerCount,
       int timeoutMs
   ) {
+    return checkKafkaReadyWithConfigProviderResilience(
+        workerProps, minBrokerCount, timeoutMs, ClusterStatus::isKafkaReady);
+  }
+
+  static boolean checkKafkaReadyWithConfigProviderResilience(
+      Map<String, String> workerProps,
+      int minBrokerCount,
+      int timeoutMs,
+      KafkaReadyChecker checker
+  ) {
     if (!hasConfigProviders(workerProps)) {
-      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
     }
 
     try {
-      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
     } catch (ConfigException e) {
       if (!isConfigProviderLoadFailure(e)) {
         throw e;
@@ -210,7 +226,7 @@ public class KafkaReadyCommand {
       }
 
       log.warn("Retrying kafka-ready check without config provider properties.");
-      return ClusterStatus.isKafkaReady(workerProps, minBrokerCount, timeoutMs);
+      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
     }
   }
 

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -185,13 +185,16 @@ public class KafkaReadyCommand {
    * Attempts the kafka-ready check, handling config provider class loading failures gracefully.
    *
    * <p>Strategy:
+   * 0. If no config.providers entries are present, run the check directly (fast path).
    * 1. Try with the full config (config providers may be loadable if on the classpath).
    * 2. If config provider class loading fails (ConfigException wrapping ClassNotFoundException),
-   *    strip config.providers entries and check for unresolved variable references.
-   * 3. If remaining properties contain unresolved ${provider:...} references (i.e. security
-   *    properties depend on config providers), skip the check with a warning — the Connect
-   *    worker will verify connectivity itself on startup.
-   * 4. Otherwise, retry the check without config.providers.
+   *    strip config.providers entries from a copy and check for unresolved variable references
+   *    in Kafka client connectivity properties (security.*, sasl.*, ssl.*).
+   * 3. If client connectivity properties contain unresolved ${provider:path:key} references,
+   *    skip the check with a warning - the Connect worker will verify connectivity on startup.
+   * 4. Otherwise, retry the check with the stripped copy (without config.providers).
+   *
+   * <p>The caller's workerProps map is never mutated.
    */
   static boolean checkKafkaReadyWithConfigProviderResilience(
       Map<String, String> workerProps,
@@ -221,9 +224,10 @@ public class KafkaReadyCommand {
       log.warn("Config provider class could not be loaded during kafka-ready check: {}",
           e.getMessage(), e);
 
-      stripConfigProviders(workerProps);
+      Map<String, String> strippedProps = new HashMap<>(workerProps);
+      stripConfigProviders(strippedProps);
 
-      List<String> unresolvedKeys = findUnresolvedConfigProviderVars(workerProps);
+      List<String> unresolvedKeys = findUnresolvedConfigProviderVars(strippedProps);
       if (!unresolvedKeys.isEmpty()) {
         log.warn("Skipping kafka-ready check - the following properties contain unresolved "
             + "config provider variable references that cannot be resolved without the "
@@ -233,7 +237,7 @@ public class KafkaReadyCommand {
       }
 
       log.warn("Retrying kafka-ready check without config provider properties.");
-      return checker.isReady(workerProps, minBrokerCount, timeoutMs);
+      return checker.isReady(strippedProps, minBrokerCount, timeoutMs);
     }
   }
 

--- a/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
+++ b/utility-belt/src/main/java/io/confluent/admin/utils/cli/KafkaReadyCommand.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import io.confluent.admin.utils.ClusterStatus;
@@ -52,6 +53,7 @@ public class KafkaReadyCommand {
 
   private static final Logger log = LogManager.getLogger(KafkaReadyCommand.class);
   public static final String KAFKA_READY = "kafka-ready";
+  private static final String CONFIG_PROVIDERS_PREFIX = "config.providers";
 
   private static ArgumentParser createArgsParser() {
     ArgumentParser kafkaReady = ArgumentParsers
@@ -118,6 +120,7 @@ public class KafkaReadyCommand {
       } else {
         if (res.getString("config") != null) {
           workerProps = Utils.propsToStringMap(Utils.loadProps(res.getString("config")));
+          stripConfigProviders(workerProps);
         }
         if (res.getString("bootstrap_servers") != null) {
           workerProps.put(
@@ -154,6 +157,34 @@ public class KafkaReadyCommand {
       System.exit(0);
     } else {
       System.exit(1);
+    }
+  }
+
+  /**
+   * Removes config.providers entries from the properties map. These entries cause
+   * ClassNotFoundException during AdminClient creation when the config provider
+   * plugin JARs are not on the kafka-ready classpath (they live on the worker's
+   * plugin.path instead). The kafka-ready preflight check does not need config
+   * providers, so stripping them is safe.
+   */
+  static void stripConfigProviders(Map<String, String> props) {
+    Iterator<Map.Entry<String, String>> it = props.entrySet().iterator();
+    boolean found = false;
+    while (it.hasNext()) {
+      String key = it.next().getKey();
+      if (key.equals(CONFIG_PROVIDERS_PREFIX) || key.startsWith(CONFIG_PROVIDERS_PREFIX + ".")) {
+        log.warn("Removing property '{}' from kafka-ready config — config provider classes "
+            + "are not needed for the preflight broker connectivity check and may not be on "
+            + "the classpath.", key);
+        it.remove();
+        found = true;
+      }
+    }
+    if (found) {
+      log.warn("Config provider properties were stripped from the kafka-ready check. "
+          + "If your Connect worker config uses config providers to resolve security "
+          + "properties (e.g. passwords from a secrets manager), ensure those values are "
+          + "also available as literal values or environment variables for the preflight check.");
     }
   }
 }

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -15,20 +15,14 @@
  */
 package io.confluent.admin.utils.cli;
 
-import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 public class KafkaReadyCommandTest {
-
-  // --- stripConfigProviders ---
 
   @Test
   public void stripConfigProviders_removesAllConfigProviderEntries() {
@@ -41,22 +35,23 @@ public class KafkaReadyCommandTest {
         "io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider");
     props.put("config.providers.secretmanager.param.aws.region", "us-east-1");
 
-    KafkaReadyCommand.stripConfigProviders(props);
+    Map<String, String> result = KafkaReadyCommand.stripConfigProviders(props);
 
-    assertThat(props).containsOnlyKeys(
+    assertThat(result).containsOnlyKeys(
         "bootstrap.servers", "security.protocol", "sasl.mechanism");
+    // original map is not mutated
+    assertThat(props).hasSize(6);
   }
 
   @Test
-  public void stripConfigProviders_noopWhenNoConfigProviders() {
+  public void stripConfigProviders_returnsOriginalWhenNoProviders() {
     Map<String, String> props = new HashMap<>();
     props.put("bootstrap.servers", "localhost:9092");
     props.put("security.protocol", "PLAINTEXT");
 
-    KafkaReadyCommand.stripConfigProviders(props);
+    Map<String, String> result = KafkaReadyCommand.stripConfigProviders(props);
 
-    assertThat(props).hasSize(2);
-    assertThat(props).containsEntry("bootstrap.servers", "localhost:9092");
+    assertThat(result).isSameAs(props);
   }
 
   @Test
@@ -69,9 +64,9 @@ public class KafkaReadyCommandTest {
     props.put("config.providers.vault.param.address", "https://vault:8200");
     props.put("ssl.truststore.location", "/etc/ssl/truststore.jks");
 
-    KafkaReadyCommand.stripConfigProviders(props);
+    Map<String, String> result = KafkaReadyCommand.stripConfigProviders(props);
 
-    assertThat(props).containsOnlyKeys("bootstrap.servers", "ssl.truststore.location");
+    assertThat(result).containsOnlyKeys("bootstrap.servers", "ssl.truststore.location");
   }
 
   @Test
@@ -82,281 +77,8 @@ public class KafkaReadyCommandTest {
     props.put("config.providers.secretmanager.class", "com.example.Provider");
     props.put("some.config.providers.unrelated", "value");
 
-    KafkaReadyCommand.stripConfigProviders(props);
+    Map<String, String> result = KafkaReadyCommand.stripConfigProviders(props);
 
-    assertThat(props).containsOnlyKeys("bootstrap.servers", "some.config.providers.unrelated");
-  }
-
-  // --- hasConfigProviders ---
-
-  @Test
-  public void hasConfigProviders_trueWhenPresent() {
-    Map<String, String> props = new HashMap<>();
-    props.put("config.providers", "secretmanager");
-
-    assertThat(KafkaReadyCommand.hasConfigProviders(props)).isTrue();
-  }
-
-  @Test
-  public void hasConfigProviders_falseWhenAbsent() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-
-    assertThat(KafkaReadyCommand.hasConfigProviders(props)).isFalse();
-  }
-
-  // --- isConfigProviderLoadFailure ---
-
-  @Test
-  public void isConfigProviderLoadFailure_trueForClassNotFoundException() {
-    ConfigException e = new ConfigException(
-        "Invalid value com.example.Provider for configuration "
-        + "config.providers.secretmanager.class: Could not load class");
-    e.initCause(new ClassNotFoundException("com.example.Provider"));
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_trueForNoClassDefFoundError() {
-    ConfigException e = new ConfigException(
-        "Invalid value com.example.Provider for configuration "
-        + "config.providers.secretmanager.class: Could not load class");
-    e.initCause(new NoClassDefFoundError("software/amazon/awssdk/core/SdkClient"));
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_trueForNestedClassNotFound() {
-    ClassNotFoundException cnfe = new ClassNotFoundException("com.example.Provider");
-    RuntimeException wrapper = new RuntimeException("wrapper", cnfe);
-    ConfigException e = new ConfigException(
-        "config.providers.vault.class: Could not load");
-    e.initCause(wrapper);
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_trueForMessageFallback() {
-    // No ClassNotFoundException in cause chain, but message matches
-    ConfigException e = new ConfigException(
-        "Invalid value com.example.Provider "
-        + "for configuration config.providers.secretmanager.class: "
-        + "Could not load config provider class or one of its dependencies");
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_falseForOtherConfigException() {
-    ConfigException e = new ConfigException("Unknown configuration key: bad.key");
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_falseForSaslClassNotFound() {
-    // CNFE for a SASL handler class should NOT be treated as a config provider failure
-    ConfigException e = new ConfigException(
-        "Invalid value com.example.SaslHandler for configuration "
-        + "sasl.client.callback.handler.class: Could not load class");
-    e.initCause(new ClassNotFoundException("com.example.SaslHandler"));
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
-  }
-
-  @Test
-  public void isConfigProviderLoadFailure_falseForSslClassNotFound() {
-    // CNFE for an SSL engine factory should NOT match
-    ConfigException e = new ConfigException(
-        "Invalid value com.example.SslFactory for configuration "
-        + "ssl.engine.factory.class: Could not load class");
-    e.initCause(new ClassNotFoundException("com.example.SslFactory"));
-
-    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
-  }
-
-  // --- findUnresolvedConfigProviderVars ---
-
-  @Test
-  public void findUnresolvedVars_detectsProviderReferences() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("ssl.keystore.password", "${secretmanager:my-secret:keystore-password}");
-    props.put("sasl.jaas.config", "${vault:secret/kafka:jaas-config}");
-    props.put("security.protocol", "SASL_SSL");
-
-    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
-
-    assertThat(unresolved).hasSize(2);
-    assertThat(unresolved).contains("ssl.keystore.password", "sasl.jaas.config");
-  }
-
-  @Test
-  public void findUnresolvedVars_ignoresNonProviderPlaceholders() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    // Shell-style ${ENV_VAR} without colons should NOT be matched
-    props.put("some.prop", "${SOME_ENV_VAR}");
-    // But provider-style ${provider:path} should be matched
-    props.put("ssl.keystore.password", "${secretmanager:my-secret:password}");
-
-    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
-
-    assertThat(unresolved).hasSize(1);
-    assertThat(unresolved).contains("ssl.keystore.password");
-  }
-
-  @Test
-  public void findUnresolvedVars_emptyWhenAllLiteral() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("ssl.keystore.password", "my-literal-password");
-    props.put("security.protocol", "SSL");
-
-    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
-
-    assertThat(unresolved).isEmpty();
-  }
-
-  @Test
-  public void findUnresolvedVars_handlesEmptyMap() {
-    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(new HashMap<>());
-
-    assertThat(unresolved).isEmpty();
-  }
-
-  @Test
-  public void findUnresolvedVars_ignoresNonClientKeys() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    // Non-client key with provider reference should be ignored
-    props.put("connector.password", "${secretmanager:secret:connector-pw}");
-    props.put("group.id", "${secretmanager:secret:group}");
-    // Client key with provider reference should be detected
-    props.put("ssl.keystore.password", "${secretmanager:secret:keystore-pw}");
-
-    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
-
-    assertThat(unresolved).hasSize(1);
-    assertThat(unresolved).contains("ssl.keystore.password");
-  }
-
-  // --- checkKafkaReadyWithConfigProviderResilience orchestration ---
-
-  @Test
-  public void resilience_noConfigProviders_callsCheckerOnce() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    AtomicInteger callCount = new AtomicInteger(0);
-    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
-      callCount.incrementAndGet();
-      return true;
-    };
-
-    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
-        props, 1, 5000, checker);
-
-    assertThat(result).isTrue();
-    assertThat(callCount.get()).isEqualTo(1);
-  }
-
-  @Test
-  public void resilience_configProvidersLoadable_succeedsFirstTry() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("config.providers", "secretmanager");
-    props.put("config.providers.secretmanager.class", "com.example.Provider");
-    AtomicInteger callCount = new AtomicInteger(0);
-    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
-      callCount.incrementAndGet();
-      return true;
-    };
-
-    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
-        props, 1, 5000, checker);
-
-    assertThat(result).isTrue();
-    assertThat(callCount.get()).isEqualTo(1);
-    // config.providers still present since first try succeeded
-    assertThat(props).containsKey("config.providers");
-  }
-
-  @Test
-  public void resilience_classNotFound_literalProps_stripsAndRetries() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("security.protocol", "SASL_SSL");
-    props.put("sasl.mechanism", "PLAIN");
-    props.put("config.providers", "secretmanager");
-    props.put("config.providers.secretmanager.class", "com.example.MissingProvider");
-    AtomicInteger callCount = new AtomicInteger(0);
-    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
-      int call = callCount.incrementAndGet();
-      if (call == 1) {
-        ConfigException ex = new ConfigException(
-            "Invalid value com.example.MissingProvider for configuration "
-            + "config.providers.secretmanager.class: Could not load");
-        ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
-        throw ex;
-      }
-      return true;
-    };
-
-    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
-        props, 1, 5000, checker);
-
-    assertThat(result).isTrue();
-    assertThat(callCount.get()).isEqualTo(2);
-    // caller's map should not be mutated
-    assertThat(props).containsKey("config.providers");
-    assertThat(props).containsKey("config.providers.secretmanager.class");
-    assertThat(props).containsKey("bootstrap.servers");
-  }
-
-  @Test
-  public void resilience_classNotFound_unresolvedVars_skipsWithWarning() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("ssl.keystore.password", "${secretmanager:secret:password}");
-    props.put("config.providers", "secretmanager");
-    props.put("config.providers.secretmanager.class", "com.example.MissingProvider");
-    AtomicInteger callCount = new AtomicInteger(0);
-    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
-      callCount.incrementAndGet();
-      ConfigException ex = new ConfigException(
-          "Invalid value com.example.MissingProvider for configuration "
-          + "config.providers.secretmanager.class: Could not load");
-      ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
-      throw ex;
-    };
-
-    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
-        props, 1, 5000, checker);
-
-    // Should skip (return true) without retrying
-    assertThat(result).isTrue();
-    assertThat(callCount.get()).isEqualTo(1);
-  }
-
-  @Test
-  public void resilience_nonProviderConfigException_rethrows() {
-    Map<String, String> props = new HashMap<>();
-    props.put("bootstrap.servers", "localhost:9092");
-    props.put("config.providers", "secretmanager");
-    props.put("config.providers.secretmanager.class", "com.example.Provider");
-    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
-      throw new ConfigException("Unknown configuration key: bad.key");
-    };
-
-    try {
-      KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
-          props, 1, 5000, checker);
-      fail("Expected ConfigException to be rethrown");
-    } catch (ConfigException e) {
-      assertThat(e.getMessage()).contains("bad.key");
-    }
+    assertThat(result).containsOnlyKeys("bootstrap.servers", "some.config.providers.unrelated");
   }
 }

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -310,9 +310,9 @@ public class KafkaReadyCommandTest {
 
     assertThat(result).isTrue();
     assertThat(callCount.get()).isEqualTo(2);
-    // config.providers should have been stripped before retry
-    assertThat(props).doesNotContainKey("config.providers");
-    assertThat(props).doesNotContainKey("config.providers.secretmanager.class");
+    // caller's map should not be mutated
+    assertThat(props).containsKey("config.providers");
+    assertThat(props).containsKey("config.providers.secretmanager.class");
     assertThat(props).containsKey("bootstrap.servers");
   }
 

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -15,14 +15,18 @@
  */
 package io.confluent.admin.utils.cli;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class KafkaReadyCommandTest {
+
+  // --- stripConfigProviders ---
 
   @Test
   public void stripConfigProviders_removesAllConfigProviderEntries() {
@@ -39,9 +43,6 @@ public class KafkaReadyCommandTest {
 
     assertThat(props).containsOnlyKeys(
         "bootstrap.servers", "security.protocol", "sasl.mechanism");
-    assertThat(props).doesNotContainKey("config.providers");
-    assertThat(props).doesNotContainKey("config.providers.secretmanager.class");
-    assertThat(props).doesNotContainKey("config.providers.secretmanager.param.aws.region");
   }
 
   @Test
@@ -54,7 +55,6 @@ public class KafkaReadyCommandTest {
 
     assertThat(props).hasSize(2);
     assertThat(props).containsEntry("bootstrap.servers", "localhost:9092");
-    assertThat(props).containsEntry("security.protocol", "PLAINTEXT");
   }
 
   @Test
@@ -63,7 +63,6 @@ public class KafkaReadyCommandTest {
     props.put("bootstrap.servers", "localhost:9092");
     props.put("config.providers", "secretmanager,vault");
     props.put("config.providers.secretmanager.class", "com.example.SecretsProvider");
-    props.put("config.providers.secretmanager.param.region", "us-east-1");
     props.put("config.providers.vault.class", "com.example.VaultProvider");
     props.put("config.providers.vault.param.address", "https://vault:8200");
     props.put("ssl.truststore.location", "/etc/ssl/truststore.jks");
@@ -74,25 +73,87 @@ public class KafkaReadyCommandTest {
   }
 
   @Test
-  public void stripConfigProviders_handlesEmptyMap() {
-    Map<String, String> props = new HashMap<>();
-
-    KafkaReadyCommand.stripConfigProviders(props);
-
-    assertThat(props).isEmpty();
-  }
-
-  @Test
   public void stripConfigProviders_doesNotRemoveSimilarKeys() {
     Map<String, String> props = new HashMap<>();
     props.put("bootstrap.servers", "localhost:9092");
     props.put("config.providers", "secretmanager");
     props.put("config.providers.secretmanager.class", "com.example.Provider");
-    // This key should NOT be removed — it doesn't match the prefix
     props.put("some.config.providers.unrelated", "value");
 
     KafkaReadyCommand.stripConfigProviders(props);
 
     assertThat(props).containsOnlyKeys("bootstrap.servers", "some.config.providers.unrelated");
+  }
+
+  // --- hasConfigProviders ---
+
+  @Test
+  public void hasConfigProviders_trueWhenPresent() {
+    Map<String, String> props = new HashMap<>();
+    props.put("config.providers", "secretmanager");
+
+    assertThat(KafkaReadyCommand.hasConfigProviders(props)).isTrue();
+  }
+
+  @Test
+  public void hasConfigProviders_falseWhenAbsent() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+
+    assertThat(KafkaReadyCommand.hasConfigProviders(props)).isFalse();
+  }
+
+  // --- isConfigProviderLoadFailure ---
+
+  @Test
+  public void isConfigProviderLoadFailure_trueForClassLoadError() {
+    ConfigException e = new ConfigException(
+        "Invalid value io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider "
+        + "for configuration config.providers.secretmanager.class: "
+        + "Could not load config provider class or one of its dependencies");
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_falseForOtherConfigException() {
+    ConfigException e = new ConfigException("Unknown configuration key: bad.key");
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
+  }
+
+  // --- findUnresolvedConfigProviderVars ---
+
+  @Test
+  public void findUnresolvedVars_detectsProviderReferences() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("ssl.keystore.password", "${secretmanager:my-secret:keystore-password}");
+    props.put("sasl.jaas.config", "${vault:secret/kafka:jaas-config}");
+    props.put("security.protocol", "SASL_SSL");
+
+    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
+
+    assertThat(unresolved).hasSize(2);
+    assertThat(unresolved).contains("ssl.keystore.password", "sasl.jaas.config");
+  }
+
+  @Test
+  public void findUnresolvedVars_emptyWhenAllLiteral() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("ssl.keystore.password", "my-literal-password");
+    props.put("security.protocol", "SSL");
+
+    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
+
+    assertThat(unresolved).isEmpty();
+  }
+
+  @Test
+  public void findUnresolvedVars_handlesEmptyMap() {
+    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(new HashMap<>());
+
+    assertThat(unresolved).isEmpty();
   }
 }

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.admin.utils.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KafkaReadyCommandTest {
+
+  @Test
+  public void stripConfigProviders_removesAllConfigProviderEntries() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("security.protocol", "SASL_SSL");
+    props.put("sasl.mechanism", "PLAIN");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class",
+        "io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider");
+    props.put("config.providers.secretmanager.param.aws.region", "us-east-1");
+
+    KafkaReadyCommand.stripConfigProviders(props);
+
+    assertThat(props).containsOnlyKeys(
+        "bootstrap.servers", "security.protocol", "sasl.mechanism");
+    assertThat(props).doesNotContainKey("config.providers");
+    assertThat(props).doesNotContainKey("config.providers.secretmanager.class");
+    assertThat(props).doesNotContainKey("config.providers.secretmanager.param.aws.region");
+  }
+
+  @Test
+  public void stripConfigProviders_noopWhenNoConfigProviders() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("security.protocol", "PLAINTEXT");
+
+    KafkaReadyCommand.stripConfigProviders(props);
+
+    assertThat(props).hasSize(2);
+    assertThat(props).containsEntry("bootstrap.servers", "localhost:9092");
+    assertThat(props).containsEntry("security.protocol", "PLAINTEXT");
+  }
+
+  @Test
+  public void stripConfigProviders_handlesMultipleProviders() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("config.providers", "secretmanager,vault");
+    props.put("config.providers.secretmanager.class", "com.example.SecretsProvider");
+    props.put("config.providers.secretmanager.param.region", "us-east-1");
+    props.put("config.providers.vault.class", "com.example.VaultProvider");
+    props.put("config.providers.vault.param.address", "https://vault:8200");
+    props.put("ssl.truststore.location", "/etc/ssl/truststore.jks");
+
+    KafkaReadyCommand.stripConfigProviders(props);
+
+    assertThat(props).containsOnlyKeys("bootstrap.servers", "ssl.truststore.location");
+  }
+
+  @Test
+  public void stripConfigProviders_handlesEmptyMap() {
+    Map<String, String> props = new HashMap<>();
+
+    KafkaReadyCommand.stripConfigProviders(props);
+
+    assertThat(props).isEmpty();
+  }
+
+  @Test
+  public void stripConfigProviders_doesNotRemoveSimilarKeys() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class", "com.example.Provider");
+    // This key should NOT be removed — it doesn't match the prefix
+    props.put("some.config.providers.unrelated", "value");
+
+    KafkaReadyCommand.stripConfigProviders(props);
+
+    assertThat(props).containsOnlyKeys("bootstrap.servers", "some.config.providers.unrelated");
+  }
+}

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -326,7 +326,9 @@ public class KafkaReadyCommandTest {
     AtomicInteger callCount = new AtomicInteger(0);
     KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
       callCount.incrementAndGet();
-      ConfigException ex = new ConfigException("Could not load");
+      ConfigException ex = new ConfigException(
+          "Invalid value com.example.MissingProvider for configuration "
+          + "config.providers.secretmanager.class: Could not load");
       ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
       throw ex;
     };

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -16,7 +16,7 @@
 package io.confluent.admin.utils.cli;
 
 import org.apache.kafka.common.config.ConfigException;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.List;

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -21,8 +21,10 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class KafkaReadyCommandTest {
 
@@ -198,5 +200,117 @@ public class KafkaReadyCommandTest {
     List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(new HashMap<>());
 
     assertThat(unresolved).isEmpty();
+  }
+
+  // --- checkKafkaReadyWithConfigProviderResilience orchestration ---
+
+  @Test
+  public void resilience_noConfigProviders_callsCheckerOnce() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    AtomicInteger callCount = new AtomicInteger(0);
+    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
+      callCount.incrementAndGet();
+      return true;
+    };
+
+    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
+        props, 1, 5000, checker);
+
+    assertThat(result).isTrue();
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void resilience_configProvidersLoadable_succeedsFirstTry() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class", "com.example.Provider");
+    AtomicInteger callCount = new AtomicInteger(0);
+    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
+      callCount.incrementAndGet();
+      return true;
+    };
+
+    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
+        props, 1, 5000, checker);
+
+    assertThat(result).isTrue();
+    assertThat(callCount.get()).isEqualTo(1);
+    // config.providers still present since first try succeeded
+    assertThat(props).containsKey("config.providers");
+  }
+
+  @Test
+  public void resilience_classNotFound_literalProps_stripsAndRetries() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("security.protocol", "SASL_SSL");
+    props.put("sasl.mechanism", "PLAIN");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class", "com.example.MissingProvider");
+    AtomicInteger callCount = new AtomicInteger(0);
+    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
+      int call = callCount.incrementAndGet();
+      if (call == 1) {
+        ConfigException ex = new ConfigException("Could not load");
+        ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
+        throw ex;
+      }
+      return true;
+    };
+
+    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
+        props, 1, 5000, checker);
+
+    assertThat(result).isTrue();
+    assertThat(callCount.get()).isEqualTo(2);
+    // config.providers should have been stripped before retry
+    assertThat(props).doesNotContainKey("config.providers");
+    assertThat(props).doesNotContainKey("config.providers.secretmanager.class");
+    assertThat(props).containsKey("bootstrap.servers");
+  }
+
+  @Test
+  public void resilience_classNotFound_unresolvedVars_skipsWithWarning() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("ssl.keystore.password", "${secretmanager:secret:password}");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class", "com.example.MissingProvider");
+    AtomicInteger callCount = new AtomicInteger(0);
+    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
+      callCount.incrementAndGet();
+      ConfigException ex = new ConfigException("Could not load");
+      ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
+      throw ex;
+    };
+
+    boolean result = KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
+        props, 1, 5000, checker);
+
+    // Should skip (return true) without retrying
+    assertThat(result).isTrue();
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void resilience_nonProviderConfigException_rethrows() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("config.providers", "secretmanager");
+    props.put("config.providers.secretmanager.class", "com.example.Provider");
+    KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
+      throw new ConfigException("Unknown configuration key: bad.key");
+    };
+
+    try {
+      KafkaReadyCommand.checkKafkaReadyWithConfigProviderResilience(
+          props, 1, 5000, checker);
+      fail("Expected ConfigException to be rethrown");
+    } catch (ConfigException e) {
+      assertThat(e.getMessage()).contains("bad.key");
+    }
   }
 }

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -228,6 +228,22 @@ public class KafkaReadyCommandTest {
     assertThat(unresolved).isEmpty();
   }
 
+  @Test
+  public void findUnresolvedVars_ignoresNonClientKeys() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    // Non-client key with provider reference should be ignored
+    props.put("connector.password", "${secretmanager:secret:connector-pw}");
+    props.put("group.id", "${secretmanager:secret:group}");
+    // Client key with provider reference should be detected
+    props.put("ssl.keystore.password", "${secretmanager:secret:keystore-pw}");
+
+    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
+
+    assertThat(unresolved).hasSize(1);
+    assertThat(unresolved).contains("ssl.keystore.password");
+  }
+
   // --- checkKafkaReadyWithConfigProviderResilience orchestration ---
 
   @Test
@@ -280,7 +296,9 @@ public class KafkaReadyCommandTest {
     KafkaReadyCommand.KafkaReadyChecker checker = (config, brokers, timeout) -> {
       int call = callCount.incrementAndGet();
       if (call == 1) {
-        ConfigException ex = new ConfigException("Could not load");
+        ConfigException ex = new ConfigException(
+            "Invalid value com.example.MissingProvider for configuration "
+            + "config.providers.secretmanager.class: Could not load");
         ex.initCause(new ClassNotFoundException("com.example.MissingProvider"));
         throw ex;
       }

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -106,9 +106,37 @@ public class KafkaReadyCommandTest {
   // --- isConfigProviderLoadFailure ---
 
   @Test
-  public void isConfigProviderLoadFailure_trueForClassLoadError() {
+  public void isConfigProviderLoadFailure_trueForClassNotFoundException() {
+    ConfigException e = new ConfigException("Could not load config provider class");
+    e.initCause(new ClassNotFoundException(
+        "io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider"));
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_trueForNoClassDefFoundError() {
+    ConfigException e = new ConfigException("Could not instantiate config provider");
+    e.initCause(new NoClassDefFoundError("software/amazon/awssdk/core/SdkClient"));
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_trueForNestedClassNotFound() {
+    ClassNotFoundException cnfe = new ClassNotFoundException("com.example.Provider");
+    RuntimeException wrapper = new RuntimeException("wrapper", cnfe);
+    ConfigException e = new ConfigException("config error");
+    e.initCause(wrapper);
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_trueForMessageFallback() {
+    // No ClassNotFoundException in cause chain, but message matches
     ConfigException e = new ConfigException(
-        "Invalid value io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider "
+        "Invalid value com.example.Provider "
         + "for configuration config.providers.secretmanager.class: "
         + "Could not load config provider class or one of its dependencies");
 
@@ -136,6 +164,21 @@ public class KafkaReadyCommandTest {
 
     assertThat(unresolved).hasSize(2);
     assertThat(unresolved).contains("ssl.keystore.password", "sasl.jaas.config");
+  }
+
+  @Test
+  public void findUnresolvedVars_ignoresNonProviderPlaceholders() {
+    Map<String, String> props = new HashMap<>();
+    props.put("bootstrap.servers", "localhost:9092");
+    // Shell-style ${ENV_VAR} without colons should NOT be matched
+    props.put("some.prop", "${SOME_ENV_VAR}");
+    // But provider-style ${provider:path} should be matched
+    props.put("ssl.keystore.password", "${secretmanager:my-secret:password}");
+
+    List<String> unresolved = KafkaReadyCommand.findUnresolvedConfigProviderVars(props);
+
+    assertThat(unresolved).hasSize(1);
+    assertThat(unresolved).contains("ssl.keystore.password");
   }
 
   @Test

--- a/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/cli/KafkaReadyCommandTest.java
@@ -109,16 +109,19 @@ public class KafkaReadyCommandTest {
 
   @Test
   public void isConfigProviderLoadFailure_trueForClassNotFoundException() {
-    ConfigException e = new ConfigException("Could not load config provider class");
-    e.initCause(new ClassNotFoundException(
-        "io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider"));
+    ConfigException e = new ConfigException(
+        "Invalid value com.example.Provider for configuration "
+        + "config.providers.secretmanager.class: Could not load class");
+    e.initCause(new ClassNotFoundException("com.example.Provider"));
 
     assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
   }
 
   @Test
   public void isConfigProviderLoadFailure_trueForNoClassDefFoundError() {
-    ConfigException e = new ConfigException("Could not instantiate config provider");
+    ConfigException e = new ConfigException(
+        "Invalid value com.example.Provider for configuration "
+        + "config.providers.secretmanager.class: Could not load class");
     e.initCause(new NoClassDefFoundError("software/amazon/awssdk/core/SdkClient"));
 
     assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
@@ -128,7 +131,8 @@ public class KafkaReadyCommandTest {
   public void isConfigProviderLoadFailure_trueForNestedClassNotFound() {
     ClassNotFoundException cnfe = new ClassNotFoundException("com.example.Provider");
     RuntimeException wrapper = new RuntimeException("wrapper", cnfe);
-    ConfigException e = new ConfigException("config error");
+    ConfigException e = new ConfigException(
+        "config.providers.vault.class: Could not load");
     e.initCause(wrapper);
 
     assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isTrue();
@@ -148,6 +152,28 @@ public class KafkaReadyCommandTest {
   @Test
   public void isConfigProviderLoadFailure_falseForOtherConfigException() {
     ConfigException e = new ConfigException("Unknown configuration key: bad.key");
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_falseForSaslClassNotFound() {
+    // CNFE for a SASL handler class should NOT be treated as a config provider failure
+    ConfigException e = new ConfigException(
+        "Invalid value com.example.SaslHandler for configuration "
+        + "sasl.client.callback.handler.class: Could not load class");
+    e.initCause(new ClassNotFoundException("com.example.SaslHandler"));
+
+    assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
+  }
+
+  @Test
+  public void isConfigProviderLoadFailure_falseForSslClassNotFound() {
+    // CNFE for an SSL engine factory should NOT match
+    ConfigException e = new ConfigException(
+        "Invalid value com.example.SslFactory for configuration "
+        + "ssl.engine.factory.class: Could not load class");
+    e.initCause(new ClassNotFoundException("com.example.SslFactory"));
 
     assertThat(KafkaReadyCommand.isConfigProviderLoadFailure(e)).isFalse();
   }


### PR DESCRIPTION
## Summary

When `CUB_KAFKA_READY_SKIP_CONFIG_PROVIDERS=true` is set, strips `config.providers` entries from the worker config before running the kafka-ready preflight check. Default behavior is unchanged.

## Problem

When a Connect worker config includes `config.providers` entries (e.g. for AWS Secrets Manager) and the security protocol is non-PLAINTEXT, the `kafka-ready` preflight fails with `ClassNotFoundException` because config provider JARs are on the worker `plugin.path` but not on `CUB_CLASSPATH`.

## Fix

Simple flag-gated approach:
- **Flag off (default):** Original behavior, no change
- **Flag on:** Strip `config.providers.*` entries from a copy of the config before passing to `ClusterStatus.isKafkaReady()`. The preflight only needs Kafka client properties (bootstrap.servers, security.*, ssl.*, sasl.*) to verify broker connectivity.

### Usage

In Dockerfile or K8s pod spec:
```
ENV CUB_KAFKA_READY_SKIP_CONFIG_PROVIDERS=true
```

## Test plan

- [x] 4 unit tests for `stripConfigProviders`: removes entries, returns original when none, multiple providers, does not remove similarly-named keys
- [x] Local Docker repro confirms SASL_SSL + config providers fails without fix and passes with flag

Fixes: https://confluentinc.atlassian.net/browse/CCDB-4523
Related: https://confluentinc.atlassian.net/browse/DP-6628