### PR TITLE
CPBR-3765: Fix ClusterWaitTest import for common-docker master builds (8.4.x + )

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -117,6 +117,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -117,13 +117,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-            <classifier>test-fixtures</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
@@ -17,7 +17,7 @@ package io.confluent.admin.utils;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.test.TestUtils;
+import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
@@ -17,7 +17,7 @@ package io.confluent.admin.utils;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.test.TestUtils;
+import org.apache.kafka.common.test.TestUtils;
 import org.junit.Test;
 
 import java.util.HashMap;

--- a/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java
@@ -17,16 +17,30 @@ package io.confluent.admin.utils;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.test.TestUtils;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 public class ClusterWaitTest {
+
+  private static final long WAIT_TIMEOUT_MS = 60_000;
+  private static final long WAIT_POLL_INTERVAL_MS = 100;
+
+  private static void waitForCondition(BooleanSupplier condition, String conditionDetails)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MS;
+    while (!condition.getAsBoolean()) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError("Condition not met: " + conditionDetails);
+      }
+      Thread.sleep(WAIT_POLL_INTERVAL_MS);
+    }
+  }
 
   @Test(timeout = 180000)
   public void isKafkaReadyWait() throws Exception {
@@ -48,7 +62,7 @@ public class ClusterWaitTest {
     });
 
     kafkaClusterThread.start();
-    TestUtils.waitForCondition(() -> !kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT).isEmpty(),
+    waitForCondition(() -> !kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT).isEmpty(),
         "unable to get bootstrap server list.");
 
     try {
@@ -87,7 +101,7 @@ public class ClusterWaitTest {
     });
 
     kafkaClusterThread.start();
-    TestUtils.waitForCondition(() -> !kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT).isEmpty(),
+    waitForCondition(() -> !kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT).isEmpty(),
             "unable to get bootstrap server list.");
     try {
       String bootstrap_broker = kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT);


### PR DESCRIPTION
## Summary

`mvn testCompile` for `utility-belt` started failing on master with `cannot find symbol: class TestUtils, location: package org.apache.kafka.test` at `ClusterWaitTest.java:20`. Failing build: https://semaphore.ci.confluent.io/jobs/0d1c6209-c757-4327-8918-e71f8c210fcf/.

This PR fixes the failure by inlining a small `waitForCondition` polling helper directly into `ClusterWaitTest`, dropping the dependency on `org.apache.kafka.test.TestUtils`. No `pom.xml` changes — only `utility-belt/src/test/java/io/confluent/admin/utils/ClusterWaitTest.java`.

## Root cause

On 2026-05-05, Apache Kafka merged [#22201](https://github.com/apache/kafka/pull/22201) (commit [`3b6c838`](https://github.com/apache/kafka/commit/3b6c8385caedc8c4b5d621682050a13581c827c8)), *"MINOR: Move client test utilities to test fixtures and resolve shadow jar conflicts"*. It physically relocated:

```
clients/src/test/java/org/apache/kafka/test/TestUtils.java
                       ↓
clients/src/testFixtures/java/org/apache/kafka/test/TestUtils.java
```

Consequence for downstream Maven consumers:

| Classifier | Before #22201 | After #22201 |
|---|---|---|
| `kafka-clients:<v>:test` | contains `TestUtils.class` | no longer contains it |
| `kafka-clients:<v>:test-fixtures` | did not exist | exists on disk during build, but **never published** (see below) |

`utility-belt/pom.xml` consumes the `test` classifier at lines 113-118, so `TestUtils` disappeared from our classpath the moment Confluent rebuilt Kafka with the upstream change. The first such build is `8.4.0-81-ccs`, which is what `common-docker` master is currently resolving.

## Why upstream’s “new home” isn’t reachable as a Maven artifact

Both Apache and Confluent enumerate which secondary JARs to publish via a hardcoded allowlist:

- `apache/kafka` `build.gradle:416-419` and `confluentinc/kafka` `build.gradle:458-462`:
  ```groovy
  ["srcJar", "javadocJar", "scaladocJar", "testJar", "testSrcJar"].forEach { taskName ->
    def task = tasks.findByName(taskName)
    if (task != null) artifact task
  }
  ```
- `testFixturesJar` (Gradle's auto-generated task from `apply plugin: 'java-test-fixtures'`) is **not on either list**, and never has been.
- I diffed the apache/kafka allowlist immediately before and after #22201: identical. The PR didn't (and intentionally doesn't) add a publishable `test-fixtures` classifier.
- Pre-#22201, the `java-test-fixtures` plugin wasn't applied at all in apache/kafka. There was no `testFixturesJar` task. Nothing to publish, ever.

So `kafka-clients:test-fixtures` is **not a regression of an artifact we used to get** — it has never existed as a published Maven artifact at any point in Kafka's history. Direct evidence: when added to this PR's pom as a dep, CI failed with `kafka-clients:jar:test-fixtures:8.4.0-81-ccs (absent)`.

## Why this isn't a Confluent build-team oversight

Reading the PR #22201 review thread, the policy direction is explicitly the *opposite* of "publish externally":

> chia7712: *"It would be great if we could remove all references to `project(':clients').sourceSets.test.output`. We could move the classes used across modules to the test-fixtures folder."*
> soarez: *"All such references were removed and disallowed — adding them now triggers a build error."*
> chia7712: *"Right now it only rejects client test code, but since other modules still depend on other's test code, this will eventually result in all test scopes being rejected as we clean them up."*

This sits in a multi-month pattern of reducing test-utility surface area:
- KAFKA-20128 (2026-02-09) — moved non-public classes into `internal` subpackages.
- KAFKA-20297 (2026-04-21) — moved `OperatingSystem`, `Java`, `Exit`, … into `internal`.
- #22201 (2026-05-05) — moved `TestUtils` out of `testJar` and into `testFixtures`.

And the new `org.apache.kafka.common.test.TestUtils` (in `kafka-test-common-runtime`) is **package-private** with the javadoc *"Not intended for use outside…"* — Apache Kafka is explicitly hiding test utilities from external consumers, not exposing more.

External consumers consuming `kafka-clients:test` to reach `TestUtils` was an unintended side-effect of the old source layout. Apache Kafka noticed the leak (the PR's stated goal: *"resolve shadow jar conflicts"*) and is actively closing it off — with code-level enforcement.

Asking Apache to publish `testFixturesJar` would be asking them to reverse the cleanup they just shipped. Asking only Confluent to publish it would create a downstream-only public surface diverging from upstream that Confluent alone would have to maintain. Neither unblocks master today.

## Alternatives I tried before this fix

1. **Switch the import to `org.apache.kafka.common.test.TestUtils`** (already on the classpath via `kafka-test-common-runtime`). CI: *"is not public in `org.apache.kafka.common.test`; cannot be accessed from outside package."* The class is package-private; its javadoc says use `org.apache.kafka.test.TestUtils` instead.
2. **Add a `kafka-clients` dep with `<classifier>test-fixtures</classifier>`.** CI: *"kafka-clients:jar:test-fixtures:8.4.0-81-ccs (absent)."* Not published — see above.

Earlier commits in this branch (`e0b01b7c2`, `351adb03b`) are those failed attempts, kept in history for traceability. The final commit (`5a1d1178e`) is the fix being shipped.

## The fix

In `ClusterWaitTest.java`:
- Drop `import org.apache.kafka.test.TestUtils;`.
- Add a private `waitForCondition(BooleanSupplier, String)` helper (~10 lines): poll-with-timeout, throws `AssertionError` on deadline.
- Replace the two `TestUtils.waitForCondition(...)` calls with the inlined `waitForCondition(...)`.

The two callsites both pass `() -> !kafkaWait.getBootstrapBrokers(SecurityProtocol.PLAINTEXT).isEmpty()` — a simple non-throwing predicate, so the parts of upstream's helper that handle in-poll throwables (transient `AssertionError`/`Exception`) aren't exercised by this test. Behavior is preserved.

### Maintenance trade-off

Inlining means we don't pick up future upstream improvements to `waitForCondition` automatically. For this case, that risk is essentially zero:
- The helper is stable polling logic that hasn't materially changed in years.
- Upstream is moving to *less* external visibility for this class, not more — they aren't going to add features and expect external consumers to track them.
- If we ever needed the fancier behaviors, the right move at that point is to vendor the full `TestUtils.java` with a recorded source revision. Premature today.

## Test plan

- [ ] Semaphore master `mvn testCompile` for `utility-belt` succeeds.
- [ ] `ClusterWaitTest#isKafkaReadyWait` and `#isKafkaReady` still wait correctly for the embedded Kafka cluster's bootstrap brokers (the only `TestUtils` use is `waitForCondition`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)