### PR TITLE
Install IBM Semeru Open JRE for s390x cp-base-java(-micro) builds

### DIFF
--- a/base-java-micro/Dockerfile.ubi9
+++ b/base-java-micro/Dockerfile.ubi9
@@ -27,28 +27,67 @@ ARG CRYPTO_POLICIES_SCRIPTS_VERSION
 ARG FINDUTILS_VERSION
 ARG HOSTNAME_VERSION
 ARG SHADOW_UTILS_VERSION
-
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo
+# libstdc++ is only consumed by the s390x branch below (the Temurin path pulls it
+# transitively via the temurin-25-jre RPM, so leaving this ARG empty for non-s390x
+# builds is fine — the suffix expands to "" and dnf installs the latest).
+ARG LIBSTDCXX_VERSION
+# s390x uses IBM Semeru Open JRE (tarball) instead of Temurin (RPM) — see base-java/Dockerfile.ubi9
+# for full rationale (FIPS via IBM JSSE2, CPACF auto-integration).
+ARG SEMERU_JRE_VERSION
+ARG SEMERU_JRE_S390X_SHA256
+ARG TARGET_ARCH
 
 RUN mkdir -p /microdir
 
-RUN echo "Installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
-    && dnf install --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs -y \
-       temurin-25-jre${TEMURIN_JDK_VERSION} \
-       procps-ng${PROCPS_VERSION} \
-       crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
-       findutils${FINDUTILS_VERSION} \
-       hostname${HOSTNAME_VERSION} \
-       shadow-utils${SHADOW_UTILS_VERSION} \
-    && dnf --installroot=/microdir clean all \
-    && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* \
-    && rm /etc/yum.repos.d/adoptium.repo # Remove temurin-jdk repo to reduce intermittent build failures
+# JRE install into the /microdir rootfs.
+#   s390x  → IBM Semeru Open JRE tarball extracted to /microdir/opt/java/openjdk,
+#            with /microdir/usr/bin/java symlinked. Non-JRE packages (procps-ng,
+#            crypto-policies-scripts, findutils, hostname, shadow-utils, libstdc++) still
+#            come via dnf — libstdc++ is needed because the tarball's libjvm.so links
+#            against libstdc++.so.6 and ubi9-micro (unlike ubi9-minimal) does not bundle
+#            it, so we install it into /microdir so the final stage's rootfs-copy carries
+#            it along.
+#
+#            After extraction we grep java.security for OpenJCEPlus — see the long-form
+#            note in base-java/Dockerfile.ubi9 for full rationale. Same regression-guard,
+#            same limitations (proves the provider line is present; does NOT prove class
+#            load at runtime or actual FIPS engagement — those need real z hardware).
+#
+#   other  → existing dnf-into-installroot path with Temurin RPM, unchanged behaviour.
+RUN if [ "$TARGET_ARCH" = ".s390x" ]; then \
+        echo "Installing IBM Semeru Open JRE ${SEMERU_JRE_VERSION} for s390x" \
+        && mkdir -p /microdir/opt/java/openjdk /microdir/usr/bin \
+        && curl -fsSL -o /tmp/semeru-jre.tar.gz \
+            "https://github.com/ibmruntimes/semeru25-binaries/releases/download/jdk-${SEMERU_JRE_VERSION}/ibm-semeru-open-jre_s390x_linux_${SEMERU_JRE_VERSION}.tar.gz" \
+        && echo "${SEMERU_JRE_S390X_SHA256}  /tmp/semeru-jre.tar.gz" | sha256sum -c - \
+        && tar -xzf /tmp/semeru-jre.tar.gz -C /microdir/opt/java/openjdk --strip-components=1 \
+        && (grep -qE "^security\.provider\.[0-9]+=OpenJCEPlus" /microdir/opt/java/openjdk/conf/security/java.security \
+              || (echo "ERROR: OpenJCEPlus provider missing from Semeru java.security — possible tarball regression" && exit 1)) \
+        && rm /tmp/semeru-jre.tar.gz \
+        && ln -sf /opt/java/openjdk/bin/java /microdir/usr/bin/java \
+        && dnf install --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs -y \
+            procps-ng${PROCPS_VERSION} \
+            crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
+            findutils${FINDUTILS_VERSION} \
+            hostname${HOSTNAME_VERSION} \
+            shadow-utils${SHADOW_UTILS_VERSION} \
+            libstdc++${LIBSTDCXX_VERSION} \
+        && dnf --installroot=/microdir clean all \
+        && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.*; \
+    else \
+        printf "[temurin-jre] \nname=temurin-jre \nbaseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \nenabled=1 \ngpgcheck=1 \ngpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n" > /etc/yum.repos.d/adoptium.repo \
+        && echo "Installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
+        && dnf install --installroot=/microdir --releasever=9 --setopt=install_weak_deps=False --nodocs -y \
+            temurin-25-jre${TEMURIN_JDK_VERSION} \
+            procps-ng${PROCPS_VERSION} \
+            crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
+            findutils${FINDUTILS_VERSION} \
+            hostname${HOSTNAME_VERSION} \
+            shadow-utils${SHADOW_UTILS_VERSION} \
+        && dnf --installroot=/microdir clean all \
+        && rm -rf /microdir/var/cache/* /microdir/var/log/dnf* /microdir/var/log/yum.* \
+        && rm /etc/yum.repos.d/adoptium.repo; \
+    fi
 
 # Create the user/group with EXPLICIT IDs inside the micro rootfs
 RUN chroot /microdir groupadd -g ${APP_GID} appuser && \

--- a/base-java-micro/pom.xml
+++ b/base-java-micro/pom.xml
@@ -142,7 +142,17 @@
                                     <FINDUTILS_VERSION>-${ubi9.findutils.version}</FINDUTILS_VERSION>
                                     <HOSTNAME_VERSION>-${ubi9.hostname.version}</HOSTNAME_VERSION>
                                     <SHADOW_UTILS_VERSION>-${ubi9.shadow-utils.version}</SHADOW_UTILS_VERSION>
+                                    <!-- libstdc++ explicitly installed for the s390x Semeru rootfs-copy path
+                                         (see Dockerfile.ubi9). XML names disallow '+'; '__plus__' encoding is
+                                         decoded by cp-build-release's dependency-update automation. -->
+                                    <LIBSTDCXX_VERSION>-${ubi9.libstdc__plus____plus__.version}</LIBSTDCXX_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
+                                    <!-- IBM Semeru Open JRE (used on s390x only; see Dockerfile.ubi9) -->
+                                    <SEMERU_JRE_VERSION>${semeru-25-jre.version}</SEMERU_JRE_VERSION>
+                                    <SEMERU_JRE_S390X_SHA256>${semeru-25-jre.s390x.sha256}</SEMERU_JRE_S390X_SHA256>
+                                    <!-- arch.type is set in .semaphore/semaphore.yml as .amd64/.arm64/.s390x.
+                                         Dockerfile branches on this to choose Temurin RPM vs Semeru tarball. -->
+                                    <TARGET_ARCH>${arch.type}</TARGET_ARCH>
                                 </args>
                             </build>
                         </image>

--- a/base-java/Dockerfile.ubi9
+++ b/base-java/Dockerfile.ubi9
@@ -27,6 +27,12 @@ ARG TEMURIN_JDK_VERSION
 ARG CRYPTO_POLICIES_SCRIPTS_VERSION
 ARG FINDUTILS_VERSION
 ARG HOSTNAME_VERSION
+# s390x uses IBM Semeru Open JRE (tarball) instead of Temurin (RPM) — required for FIPS
+# (BoringSSL FIPS has no s390x build; Semeru ships IBM JSSE2 FIPS natively) and to
+# auto-leverage CPACF hardware crypto.
+ARG SEMERU_JRE_VERSION
+ARG SEMERU_JRE_S390X_SHA256
+ARG TARGET_ARCH
 
 # Remember where we came from
 LABEL io.confluent.docker.git.repo="confluentinc/common-docker"
@@ -50,17 +56,47 @@ LABEL io.confluent.docker=true
 ENV LANG="C.UTF-8"
 ENV USE_LOG4J_2="True"
 
-RUN printf "[temurin-jre] \n\
-name=temurin-jre \n\
-baseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \n\
-enabled=1 \n\
-gpgcheck=1 \n\
-gpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n\
-" > /etc/yum.repos.d/adoptium.repo
+# JRE install — arch-specific.
+#   s390x  → IBM Semeru Open JRE, tarball from github.com/ibmruntimes/semeru25-binaries
+#            (IBM does not publish Semeru in a yum/dnf repo). Extracted to /opt/java/openjdk
+#            with /usr/bin/java symlinked so downstream apps work identically to the RPM path.
+#            The legal/ tree inside the tarball is preserved under /opt/java/openjdk/legal/
+#            (GPLv2+CPE attribution).
+#
+#            After extraction we grep java.security for OpenJCEPlus — IBM's FIPS-capable
+#            crypto provider that ships in Semeru Open Edition and (on s390x specifically)
+#            auto-routes through CPACF hardware crypto. The check guards against a future
+#            Semeru tarball refresh silently dropping or renaming the provider entry, which
+#            would regress the s390x FIPS path that is the entire reason we're on Semeru
+#            here instead of Temurin.
+#
+#            What this proves: the provider line is present in the config shipped by IBM.
+#            What it does NOT prove: (1) com.ibm.crypto.plus.provider.OpenJCEPlus actually
+#            loads at runtime — JRE has no compiler and jrunscript was removed in JDK 15+,
+#            so a class-load test would require shipping a precompiled .class file just to
+#            run it; (2) FIPS mode actually engages — that needs a real z box with CPACF
+#            and an actual Cipher.getInstance(...) call, neither of which QEMU can emulate.
+#
+#   other  → Eclipse Temurin JRE via Adoptium RPM repo (existing path, unchanged behaviour).
+RUN if [ "$TARGET_ARCH" = ".s390x" ]; then \
+        echo "Installing IBM Semeru Open JRE ${SEMERU_JRE_VERSION} for s390x" \
+        && microdnf install -y tar gzip \
+        && mkdir -p /opt/java/openjdk \
+        && curl -fsSL -o /tmp/semeru-jre.tar.gz \
+            "https://github.com/ibmruntimes/semeru25-binaries/releases/download/jdk-${SEMERU_JRE_VERSION}/ibm-semeru-open-jre_s390x_linux_${SEMERU_JRE_VERSION}.tar.gz" \
+        && echo "${SEMERU_JRE_S390X_SHA256}  /tmp/semeru-jre.tar.gz" | sha256sum -c - \
+        && tar -xzf /tmp/semeru-jre.tar.gz -C /opt/java/openjdk --strip-components=1 \
+        && (grep -qE "^security\.provider\.[0-9]+=OpenJCEPlus" /opt/java/openjdk/conf/security/java.security \
+              || (echo "ERROR: OpenJCEPlus provider missing from Semeru java.security — possible tarball regression" && exit 1)) \
+        && rm /tmp/semeru-jre.tar.gz \
+        && ln -sf /opt/java/openjdk/bin/java /usr/bin/java; \
+    else \
+        printf "[temurin-jre] \nname=temurin-jre \nbaseurl=https://adoptium.jfrog.io/artifactory/rpm/rhel/\$releasever/\$basearch \nenabled=1 \ngpgcheck=1 \ngpgkey=https://adoptium.jfrog.io/artifactory/api/gpg/key/public \n" > /etc/yum.repos.d/adoptium.repo \
+        && echo "installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
+        && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION}; \
+    fi
 
-RUN echo "installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
-    && microdnf install -y temurin-25-jre${TEMURIN_JDK_VERSION} \
-    && microdnf install -y procps-ng${PROCPS_VERSION} \
+RUN microdnf install -y procps-ng${PROCPS_VERSION} \
     && microdnf install -y crypto-policies-scripts${CRYPTO_POLICIES_SCRIPTS_VERSION} \
     && microdnf install -y findutils${FINDUTILS_VERSION} \
     && microdnf install -y hostname${HOSTNAME_VERSION} \
@@ -69,7 +105,7 @@ RUN echo "installing temurin-25-jre:${TEMURIN_JDK_VERSION}" \
     && mkdir -p /etc/confluent/docker /usr/logs \
     && chown appuser:appuser -R /etc/confluent/ /usr/logs \
     && mkdir /licenses \
-    && rm /etc/yum.repos.d/adoptium.repo # Remove temurin-jdk repo to reduce intermittent build failures
+    && rm -f /etc/yum.repos.d/adoptium.repo
 
 # enable FIPS in docker image, this will only work if underlying OS has FIPS enabled as well else is a NO OP.
 RUN update-crypto-policies --set FIPS

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -140,6 +140,12 @@
                                     <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                                     <HOSTNAME_VERSION>-${ubi9-minimal.hostname.version}</HOSTNAME_VERSION>
                                     <CP_DOCKER_UTILS_VERSION>${git-repo.cp-docker-utils.tag}</CP_DOCKER_UTILS_VERSION>
+                                    <!-- IBM Semeru Open JRE (used on s390x only; see Dockerfile.ubi9) -->
+                                    <SEMERU_JRE_VERSION>${semeru-25-jre.version}</SEMERU_JRE_VERSION>
+                                    <SEMERU_JRE_S390X_SHA256>${semeru-25-jre.s390x.sha256}</SEMERU_JRE_S390X_SHA256>
+                                    <!-- arch.type is set in .semaphore/semaphore.yml as .amd64/.arm64/.s390x.
+                                         Dockerfile branches on this to choose Temurin RPM vs Semeru tarball. -->
+                                    <TARGET_ARCH>${arch.type}</TARGET_ARCH>
                                 </args>
                             </build>
                         </image>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
         <ubi9.findutils.version>4.8.0-7.el9</ubi9.findutils.version>
         <ubi9.hostname.version>3.23-6.el9</ubi9.hostname.version>
         <ubi9.shadow-utils.version>4.9-15.el9</ubi9.shadow-utils.version>
+        <!-- libstdc++ is required in /microdir for cp-base-java-micro's s390x build:
+             the Semeru tarball's libjvm.so links libstdc++.so.6, and ubi9-micro (unlike
+             ubi9-minimal) does not bundle the C++ stdlib. XML element names cannot contain
+             '+'; the cp-build-release dependency-update automation decodes '__plus__' back
+             to '+' at the upstream-lookup boundary. See PROPERTY_NAME_ENCODING_MAP in
+             scheduled_tasks/update_docker_dependencies/lib/constants.py. -->
+        <ubi9.libstdc__plus____plus__.version>11.5.0-11.el9</ubi9.libstdc__plus____plus__.version>
 
         <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
@@ -128,6 +135,20 @@
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.171</git-repo.confluent-docker-utils.tag>
         <git-repo.cp-docker-utils.tag>v1.0.11</git-repo.cp-docker-utils.tag>
+
+        <!-- IBM Semeru Runtime Open Edition (s390x JRE for cp-base-java*)
+             Tarball distribution from github.com/ibmruntimes/semeru25-binaries.
+             IBM does not publish Semeru in a yum/dnf repo, so this install path
+             is curl+sha256+tar rather than the RPM pattern used for Temurin.
+             URL template (see base-java/Dockerfile.ubi9 and base-java-micro/Dockerfile.ubi9):
+               https://github.com/ibmruntimes/semeru25-binaries/releases/download/
+                 jdk-${semeru-25-jre.version}/
+                 ibm-semeru-open-jre_<arch>_linux_${semeru-25-jre.version}.tar.gz
+             Only s390x is consumed today (see service.yml s390x_docker_repos).
+             When refreshing: bump version, fetch new sha256 from the matching
+             *.tar.gz.sha256.txt asset on the same GitHub release. -->
+        <semeru-25-jre.version>25.0.3.0</semeru-25-jre.version>
+        <semeru-25-jre.s390x.sha256>5f24293d1352355c1c77bd373a7fcf68a0f9dd986cc575f208cc72978c4ada53</semeru-25-jre.s390x.sha256>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.3-trixie</golang.image.version>


### PR DESCRIPTION
## Summary

`cp-base-java` and `cp-base-java-micro` install **IBM Semeru Open JRE 25** on s390x builds. amd64 and arm64 builds continue to install **Eclipse Temurin 25** from the Adoptium yum repo. Selection is driven by the existing `arch.type` Maven property already set in `.semaphore/{semaphore,cp_dockerfile_build}.yml`.

## How it works

- On s390x, the new conditional in both `Dockerfile.ubi9` files:
  - `curl`s the Semeru tarball from the [`ibmruntimes/semeru25-binaries`](https://github.com/ibmruntimes/semeru25-binaries/releases) GitHub release
  - sha256-verifies the download against a pom-pinned hash
  - extracts to `/opt/java/openjdk` (preserving the `legal/` tree for GPLv2+CPE attribution)
  - symlinks `/usr/bin/java` so downstream apps work identically to the RPM path
- On amd64/arm64, the existing Adoptium RPM install path runs unchanged.
- `cp-base-java-micro` additionally adds `libstdc++` to the dnf install into `/microdir`. The final stage of `-micro` is `ubi9-micro`, which doesn't bundle the C++ stdlib that Semeru's `libjvm.so` links against; the rootfs-copy stage now explicitly carries it.

## New pom properties

| Property | Value | Notes |
| - | - | - |
| `semeru-25-jre.version` | `25.0.3.0` | URL template uses this for both the GitHub release tag and the asset filename |
| `semeru-25-jre.s390x.sha256` | `5f24293d…` | SHA256 of `ibm-semeru-open-jre_s390x_linux_25.0.3.0.tar.gz` |
| `ubi9.libstdc__plus____plus__.version` | `11.5.0-11.el9` | XML element names disallow `+`; `__plus__` encoding pairs with the decoder in the paired cp-build-release PR |

## Paired PR

[`confluentinc/cp-build-release#577`](https://github.com/confluentinc/cp-build-release/pull/577) — adds the `__plus__` decoder to the dependency-update automation so future scheduled runs can resolve `ubi9.libstdc__plus____plus__.version` to `libstdc++`. **That PR should land first or alongside this one.**

## Test plan

- [x] Local s390x build via QEMU on amd64 (`-Darch.type=.s390x -Ddocker.buildx.platforms=linux/s390x`): both `cp-base-java` (178 MB) and `cp-base-java-micro` (152 MB) build successfully; `java -version` returns IBM Semeru / Eclipse OpenJ9 on `Linux s390x-64-Bit`.
- [x] Local amd64 build (`-Darch.type=.amd64`): `cp-base-java` still installs Eclipse Temurin via Adoptium RPM, `/opt/java/openjdk` does not exist, `/usr/bin/java` resolves to `/usr/lib/jvm/java-25-temurin-jre/bin/java` (existing path unchanged).
- [x] Sanity: GPLv2+CPE `legal/` directory preserved under `/opt/java/openjdk/legal/`; `update-crypto-policies` runs unchanged.
- [ ] CI s390x build pipeline (this PR).
- [ ] Downstream component team smoke test on s390x once images are promoted.