### PR TITLE
CPBR-3749: bump confluent-docker-utils to v0.0.172 (CVE-2026-25645)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.2-trixie</golang.image.version>


### PR DESCRIPTION
Bumps `confluent-docker-utils` pin from `v0.0.169` → `v0.0.172` on FedRAMP `8.0.2-cp7`. Picks up CVE-2026-25645 fix (`requests~=2.33.0`) reapplied via confluent-docker-utils#224.

**Note:** `requests 2.33.x` requires Python ≥3.10. Python 3.14 base upgrade on this branch will follow in a separate commit/PR.

**Tag history:**
- `v0.0.170` — original bump (#222)
- `v0.0.171` — published after revert (#223) → CVE re-introduced
- `v0.0.172` — current, CVE fix reapplied (#224)

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749