### PR TITLE
CPBR-3749: upgrade Python to 3.14 in cp-base-new (CVE-2026-25645)

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
-      - sem-version python 3.9
+      - sem-version python 3.14
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,7 +25,7 @@ global_job_config:
     commands:
       - checkout
       - if [[ $SEMAPHORE_GIT_BRANCH =~ ^7\..* ]]; then sem-version java 8; else sem-version java 17; fi
-      - sem-version python 3.9
+      - sem-version python 3.14
       - . vault-setup
       - . cache-maven restore
       - pip install tox==3.28.0

--- a/base-java/requirements.txt
+++ b/base-java/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.162
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.169

--- a/base-java/tox.ini
+++ b/base-java/tox.ini
@@ -6,10 +6,10 @@ toxworkdir = /var/tmp
 deps =
     -rrequirements.txt
     flake8
-    pytest == 4.6.4
-    pytest-xdist == 1.29.0
-    pytest-cov == 2.7.1
-    sphinx!=1.2b2,<2.0.0
+    pytest ~= 8.0.0
+    pytest-xdist ~= 3.0.0
+    pytest-cov ~= 4.0.0
+    sphinx ~= 7.0.0
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True

--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -104,6 +104,7 @@ RUN microdnf --nodocs -y install yum \
         Python-${PYTHON314_VERSION}.tgz \
     && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
     && python3 -m pip uninstall -y sigstore \
+    && rm -rf /usr/local/lib/python3.9/site-packages/* \
     && yum remove -y python3-pip \
     && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
     && tar -xzf Python-${PYTHON314_VERSION}.tgz \

--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -55,7 +55,7 @@ ARG OPENSSL_VERSION=""
 ARG OPENSSL_LIBS_VERSION=""
 ARG WGET_VERSION=""
 ARG NETCAT_VERSION=""
-ARG PYTHON39_VERSION=""
+ARG PYTHON314_VERSION=""
 ARG TAR_VERSION=""
 ARG PROCPS_VERSION=""
 ARG KRB5_WORKSTATION_VERSION=""
@@ -69,7 +69,6 @@ ARG CURL_VERSION=""
 ARG TEMURIN_JDK_VERSION=""
 
 # Python Module Versions
-ARG PYTHON_PIP_VERSION=""
 ARG PYTHON_SETUPTOOLS_VERSION=""
 
 # Confluent Docker Utils Version (Namely the tag or branch to grab from git to install)
@@ -77,6 +76,59 @@ ARG PYTHON_CONFLUENT_DOCKER_UTILS_VERSION="master"
 
 # This can be overriden for an offline/air-gapped builds
 ARG PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC="git+https://github.com/confluentinc/confluent-docker-utils@${PYTHON_CONFLUENT_DOCKER_UTILS_VERSION}"
+
+# Install Python 3.14 from source FIRST
+RUN microdnf --nodocs -y install yum \
+    && yum --nodocs install -y --setopt=install_weak_deps=False \
+        gcc \
+        gcc-c++ \
+        make \
+        tar \
+        gzip \
+        openssl-devel \
+        ca-certificates \
+        bzip2-devel \
+        libffi-devel \
+        zlib-devel \
+        sqlite-devel \
+        findutils \
+        python3-pip \
+    && python3 -m pip install --upgrade pip \
+    && python3 -m pip install sigstore \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz \
+    && curl -fSLO https://www.python.org/ftp/python/${PYTHON314_VERSION}/Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m sigstore verify identity \
+        --bundle Python-${PYTHON314_VERSION}.tgz.sigstore \
+        --cert-identity hugo@python.org \
+        --cert-oidc-issuer https://github.com/login/oauth \
+        Python-${PYTHON314_VERSION}.tgz \
+    && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
+    && python3 -m pip uninstall -y sigstore \
+    && yum remove -y python3-pip \
+    && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
+    && tar -xzf Python-${PYTHON314_VERSION}.tgz \
+    && cd Python-${PYTHON314_VERSION} \
+    && ./configure --enable-optimizations \
+                   --with-ensurepip=install \
+                   --with-openssl=/usr \
+                   --with-openssl-rpath=auto \
+    && make -j$(nproc) \
+    && make altinstall \
+    && cd .. \
+    && rm -rf Python-${PYTHON314_VERSION}* \
+    && rm -f /var/lib/alternatives/python /var/lib/alternatives/python3 /var/lib/alternatives/pip /var/lib/alternatives/pip3 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/python python /usr/local/bin/python3.14 100 \
+    && update-alternatives --install /usr/bin/pip3 pip3 /usr/local/bin/pip3.14 100 \
+    && update-alternatives --install /usr/bin/pip pip /usr/local/bin/pip3.14 100 \
+    && python3 -c "import ssl; print('SSL module loaded successfully')" \
+    && python --version \
+    && python3 --version \
+    && pip --version \
+    && pip3 --version \
+    && yum remove -y gcc gcc-c++ make openssl-devel bzip2-devel libffi-devel zlib-devel sqlite-devel \
+    && yum clean all \
+    && rm -rf /tmp/* /root/.cache
 
 RUN printf "[temurin-jdk] \n\
 name=temurin-jdk \n\
@@ -91,8 +143,6 @@ RUN microdnf --nodocs -y install \
         git \
         "wget${WGET_VERSION}" \
         "nmap-ncat${NETCAT_VERSION}" \
-        "python3${PYTHON39_VERSION}" \
-        "python3-pip${PYTHON_PIP_VERSION}" \
         "tar${TAR_VERSION}" \
         "procps-ng${PROCPS_VERSION}" \
         "krb5-workstation${KRB5_WORKSTATION_VERSION}" \
@@ -108,8 +158,6 @@ RUN microdnf --nodocs -y install \
         "openssl${OPENSSL_VERSION}" \
         "openssl-libs${OPENSSL_LIBS_VERSION}" \
     && microdnf reinstall -y openssl-libs \
-    && alternatives --install /usr/bin/python python /usr/bin/python3 2000 \
-    && alternatives --set python /usr/bin/python3 \
     && python3 -m pip install --upgrade "setuptools${PYTHON_SETUPTOOLS_VERSION}" \
     && python3 -m pip install --prefer-binary --prefix=/usr/local --upgrade "${PYTHON_CONFLUENT_DOCKER_UTILS_INSTALL_SPEC}" \
     && microdnf clean all \

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -133,7 +133,7 @@
                         <OPENSSL_LIBS_VERSION>-${ubi9-minimal.openssl-libs.version}</OPENSSL_LIBS_VERSION>
                         <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                         <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                        <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                        <PYTHON314_VERSION>${python-runtime.3-14.version}</PYTHON314_VERSION>
                         <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                         <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                         <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}</KRB5_WORKSTATION_VERSION>
@@ -144,7 +144,6 @@
                         <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                         <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                         <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                        <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                         <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}</PYTHON_SETUPTOOLS_VERSION>
                         <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>${git-repo.confluent-docker-utils.tag}</PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>
                         <SKIP_SECURITY_UPDATE_CHECK>${docker.skip-security-update-check}</SKIP_SECURITY_UPDATE_CHECK>
@@ -165,7 +164,7 @@
                                     <OPENSSL_LIBS_VERSION>-${ubi9-minimal.openssl-libs.version}</OPENSSL_LIBS_VERSION>
                                     <WGET_VERSION>-${ubi9-minimal.wget.version}</WGET_VERSION>
                                     <NETCAT_VERSION>-${ubi9-minimal.nmap-ncat.version}</NETCAT_VERSION>
-                                    <PYTHON39_VERSION>-${ubi9-minimal.python3.version}</PYTHON39_VERSION>
+                                    <PYTHON314_VERSION>${python-runtime.3-14.version}</PYTHON314_VERSION>
                                     <TAR_VERSION>-${ubi9-minimal.tar.version}</TAR_VERSION>
                                     <PROCPS_VERSION>-${ubi9-minimal.procps-ng.version}</PROCPS_VERSION>
                                     <KRB5_WORKSTATION_VERSION>-${ubi9-minimal.krb5-workstation.version}
@@ -177,7 +176,6 @@
                                     <FINDUTILS_VERSION>-${ubi9-minimal.findutils.version}</FINDUTILS_VERSION>
                                     <CRYPTO_POLICIES_SCRIPTS_VERSION>-${ubi9-minimal.crypto-policies-scripts.version}</CRYPTO_POLICIES_SCRIPTS_VERSION>
                                     <TEMURIN_JDK_VERSION>-${ubi9-minimal.temurin-21-jdk.version}</TEMURIN_JDK_VERSION>
-                                    <PYTHON_PIP_VERSION>-${ubi9-minimal.python3-pip.version}</PYTHON_PIP_VERSION>
                                     <PYTHON_SETUPTOOLS_VERSION>==${python.setuptools.version}
                                     </PYTHON_SETUPTOOLS_VERSION>
                                     <PYTHON_CONFLUENT_DOCKER_UTILS_VERSION>

--- a/base/requirements.txt
+++ b/base/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/confluentinc/confluent-docker-utils@v0.0.162
+git+https://github.com/confluentinc/confluent-docker-utils@v0.0.169

--- a/base/tox.ini
+++ b/base/tox.ini
@@ -6,10 +6,10 @@ toxworkdir = /var/tmp
 deps =
     -rrequirements.txt
     flake8
-    pytest == 4.6.4
-    pytest-xdist == 1.29.0
-    pytest-cov == 2.7.1
-    sphinx!=1.2b2,<2.0.0
+    pytest ~= 8.0.0
+    pytest-xdist ~= 3.0.0
+    pytest-cov ~= 4.0.0
+    sphinx ~= 7.0.0
 install_command = pip install -U {packages}
 recreate = True
 skipsdist = True

--- a/pom.xml
+++ b/pom.xml
@@ -66,28 +66,28 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1777452756</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.7-1777857794</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.7-1777857961</ubi9-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1778735208</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1777876409</ubi9-micro.image.version>
+        <ubi9-minimal.image.version>9.8-1777460003</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
 
-        <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
+        <ubi9-minimal.openssl.version>3.5.5-2.el9_8</ubi9-minimal.openssl.version>
         <!-- OpenSSL-libs version (must match openssl version exactly for FIPS compliance) -->
-        <ubi9-minimal.openssl-libs.version>3.5.1-7.el9_7</ubi9-minimal.openssl-libs.version>
+        <ubi9-minimal.openssl-libs.version>3.5.5-2.el9_8</ubi9-minimal.openssl-libs.version>
         <!-- OpenSSL version that is FIPS compliant (for source compilation in base image) -->
         <fips.openssl.version>3.1.2</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
-        <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
+        <ubi9-minimal.nmap-ncat.version>7.92-5.el9</ubi9-minimal.nmap-ncat.version>
+        <ubi9-minimal.tar.version>1.34-11.el9</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
-        <ubi9-minimal.krb5-workstation.version>1.21.1-9.el9_7</ubi9-minimal.krb5-workstation.version>
+        <ubi9-minimal.krb5-workstation.version>1.21.1-10.el9_8</ubi9-minimal.krb5-workstation.version>
         <ubi9-minimal.iputils.version>20210202-15.el9_7</ubi9-minimal.iputils.version>
         <ubi9-minimal.hostname.version>3.23-6.el9</ubi9-minimal.hostname.version>
         <ubi9-minimal.xz-libs.version>5.2.5-8.el9_0</ubi9-minimal.xz-libs.version>
-        <ubi9-minimal.glibc.version>2.34-231.el9_7.10</ubi9-minimal.glibc.version>
+        <ubi9-minimal.glibc.version>2.34-266.el9_8</ubi9-minimal.glibc.version>
         <ubi9-minimal.findutils.version>4.8.0-7.el9</ubi9-minimal.findutils.version>
-        <ubi9-minimal.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9-minimal.crypto-policies-scripts.version>
+        <ubi9-minimal.crypto-policies-scripts.version>20260224-1.gitea0f072.el9_8</ubi9-minimal.crypto-policies-scripts.version>
         <ubi9-minimal.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9-minimal.temurin-21-jdk.version>
         <ubi9-minimal.python3-pip.version>21.3.1-1.el9</ubi9-minimal.python3-pip.version>
 
@@ -95,11 +95,11 @@
         <ubi8-minimal.nmap-ncat.version>7.92-2.el8_10</ubi8-minimal.nmap-ncat.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
-        <ubi8-minimal.krb5-workstation.version>1.18.2-32.el8_10</ubi8-minimal.krb5-workstation.version>
+        <ubi8-minimal.krb5-workstation.version>1.18.2-34.el8_10</ubi8-minimal.krb5-workstation.version>
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>
-        <ubi8-minimal.glibc.version>2.28-251.el8_10.31</ubi8-minimal.glibc.version>
+        <ubi8-minimal.glibc.version>2.28-251.el8_10.34</ubi8-minimal.glibc.version>
         <ubi8-minimal.curl.version>7.61.1-34.el8_10.11</ubi8-minimal.curl.version>
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
@@ -114,7 +114,7 @@
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
-        <golang.image.version>1.26.2-trixie</golang.image.version>
+        <golang.image.version>1.26.3-trixie</golang.image.version>
 
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <!-- Redhat Package Versions -->
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
         <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.3</ubi9-minimal.python3.version>
         <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
         <ubi9-minimal.krb5-workstation.version>1.21.1-9.el9_7</ubi9-minimal.krb5-workstation.version>
@@ -94,7 +93,6 @@
 
         <ubi8-minimal.wget.version>1.19.5-12.el8_10</ubi8-minimal.wget.version>
         <ubi8-minimal.nmap-ncat.version>7.92-2.el8_10</ubi8-minimal.nmap-ncat.version>
-        <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
         <ubi8-minimal.krb5-workstation.version>1.18.2-32.el8_10</ubi8-minimal.krb5-workstation.version>
@@ -105,13 +103,15 @@
         <ubi8-minimal.curl.version>7.61.1-34.el8_10.11</ubi8-minimal.curl.version>
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
-        <ubi8-minimal.python39-pip.version>20.2.4-9.module+el8.10.0+21329+8d76b841</ubi8-minimal.python39-pip.version>
 
-        <!-- Python Package Versions -->
+        <!-- Python Runtime Versions -->
+        <python-runtime.3-14.version>3.14.5</python-runtime.3-14.version>
+
+        <!-- PyPI Package Versions -->
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.2-trixie</golang.image.version>

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: common-docker
 lang: python
-lang_version: 3.9
+lang_version: "3.14"
 git:
   enable: true
 semaphore:


### PR DESCRIPTION
## Why
- `confluent-docker-utils v0.0.172` needs `requests~=2.33.0` (CVE-2026-25645) → requires Python ≥3.10
- cp7 ships Python 3.9.25 → blocks the CVE fix
- Bot's auto-update #1778 bundled here because CI was failing on the python update without it

## Changes
- **`base/Dockerfile.ubi9`**: build Python 3.14 from source (sigstore-verified); drop python3.9 install + alternatives; clean orphan Py3.9 site-packages
- **`pom.xml` / `base/pom.xml`**: add `python-runtime.3-14.version=3.14.5`; drop 3 orphan props; bump docker-utils `v0.0.169 → v0.0.172`; refresh UBI 9 pins (crypto-policies-scripts, openssl, glibc, krb5, etc.)
- **`.semaphore/*.yml`, `service.yml`**: Python 3.9 → 3.14
- **`base/requirements.txt`, `base/tox.ini`, `base-java/{requirements,tox}`**: Python 3.14 compat bumps

## Notes

- Verified CVE-2026-25645 cleared in build images (Trivy-scannable orphan `requests-2.32.5` removed)
https://semaphore.ci.confluent.io/workflows/a6e2b2f5-9d96-4c49-b705-115e46ced266?pipeline_id=36d54305-d49e-4637-b6e4-1147d261342b

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749