### PR TITLE
CPBR-3749: update Docker dependencies on 8.0.2-cp7 (cherry-pick of auto-update PR #1778)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,29 +66,29 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1777452756</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.7-1777857794</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.7-1777857961</ubi9-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1778735208</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1777876409</ubi9-micro.image.version>
+        <ubi9-minimal.image.version>9.8-1777460003</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
 
-        <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
+        <ubi9-minimal.openssl.version>3.5.5-2.el9_8</ubi9-minimal.openssl.version>
         <!-- OpenSSL-libs version (must match openssl version exactly for FIPS compliance) -->
-        <ubi9-minimal.openssl-libs.version>3.5.1-7.el9_7</ubi9-minimal.openssl-libs.version>
+        <ubi9-minimal.openssl-libs.version>3.5.5-2.el9_8</ubi9-minimal.openssl-libs.version>
         <!-- OpenSSL version that is FIPS compliant (for source compilation in base image) -->
         <fips.openssl.version>3.1.2</fips.openssl.version>
         <!-- Redhat Package Versions -->
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
-        <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.3</ubi9-minimal.python3.version>
-        <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
+        <ubi9-minimal.nmap-ncat.version>7.92-5.el9</ubi9-minimal.nmap-ncat.version>
+        <ubi9-minimal.python3.version>3.9.25-7.el9_8</ubi9-minimal.python3.version>
+        <ubi9-minimal.tar.version>1.34-11.el9</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
-        <ubi9-minimal.krb5-workstation.version>1.21.1-9.el9_7</ubi9-minimal.krb5-workstation.version>
+        <ubi9-minimal.krb5-workstation.version>1.21.1-10.el9_8</ubi9-minimal.krb5-workstation.version>
         <ubi9-minimal.iputils.version>20210202-15.el9_7</ubi9-minimal.iputils.version>
         <ubi9-minimal.hostname.version>3.23-6.el9</ubi9-minimal.hostname.version>
         <ubi9-minimal.xz-libs.version>5.2.5-8.el9_0</ubi9-minimal.xz-libs.version>
-        <ubi9-minimal.glibc.version>2.34-231.el9_7.10</ubi9-minimal.glibc.version>
+        <ubi9-minimal.glibc.version>2.34-266.el9_8</ubi9-minimal.glibc.version>
         <ubi9-minimal.findutils.version>4.8.0-7.el9</ubi9-minimal.findutils.version>
-        <ubi9-minimal.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9-minimal.crypto-policies-scripts.version>
+        <ubi9-minimal.crypto-policies-scripts.version>20260224-1.gitea0f072.el9_8</ubi9-minimal.crypto-policies-scripts.version>
         <ubi9-minimal.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9-minimal.temurin-21-jdk.version>
         <ubi9-minimal.python3-pip.version>21.3.1-1.el9</ubi9-minimal.python3-pip.version>
 
@@ -97,11 +97,11 @@
         <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
-        <ubi8-minimal.krb5-workstation.version>1.18.2-32.el8_10</ubi8-minimal.krb5-workstation.version>
+        <ubi8-minimal.krb5-workstation.version>1.18.2-34.el8_10</ubi8-minimal.krb5-workstation.version>
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>
-        <ubi8-minimal.glibc.version>2.28-251.el8_10.31</ubi8-minimal.glibc.version>
+        <ubi8-minimal.glibc.version>2.28-251.el8_10.34</ubi8-minimal.glibc.version>
         <ubi8-minimal.curl.version>7.61.1-34.el8_10.11</ubi8-minimal.curl.version>
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
@@ -111,10 +111,10 @@
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
-        <golang.image.version>1.26.2-trixie</golang.image.version>
+        <golang.image.version>1.26.3-trixie</golang.image.version>
 
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check


### PR DESCRIPTION
## Why
- Cherry-pick of bot's auto-update commit from #1778 (auto-closed when CI failed)
- Refreshes stale UBI 9 pins (`crypto-policies-scripts-...el9_7` pruned from mirror) + bumps `confluent-docker-utils v0.0.169 → v0.0.172` (CVE-2026-25645)

## Changes
- `pom.xml`: bumps ~15 UBI 9 pins + docker-utils tag (cherry-pick of `181df6a2e` from #1778)

## Notes
- ⚠️ CI will FAIL alone (docker-utils v0.0.172 needs Python ≥3.10; cp7 still on 3.9)
- Must merge **together with #1780** (Python 3.14 upgrade) — needs admin force-merge on one

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3749