### PR TITLE
Update Docker dependencies for 7.9.7-post (2026-05-20)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1778072014</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.7-1777857794</ubi9-micro.image.version>
+        <ubi8-minimal.image.version>8.10-1778735208</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1777876409</ubi9-micro.image.version>
 
         <!-- OS Package Versions -->
         <ubi8-minimal.openssl.version>1.1.1k-15.el8_6</ubi8-minimal.openssl.version>
@@ -74,7 +74,7 @@
         <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
-        <ubi8-minimal.krb5-workstation.version>1.18.2-33.el8_10</ubi8-minimal.krb5-workstation.version>
+        <ubi8-minimal.krb5-workstation.version>1.18.2-34.el8_10</ubi8-minimal.krb5-workstation.version>
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>


### PR DESCRIPTION
## Summary
- Bump `ubi8-minimal.image.version` to `8.10-1778735208`
- Bump `ubi9-micro.image.version` to `9.8-1777876409`
- Bump `ubi8-minimal.krb5-workstation.version` to `1.18.2-34.el8_10`
- `git-repo.confluent-docker-utils.tag` intentionally NOT bumped (kept at `v0.0.171`)

Re-raises #1788 without the confluent-docker-utils tag bump that caused the CI failure.

## Test plan
- [ ] CI checks pass