### PR TITLE
Update Docker dependencies for 8.1.3-post (2026-05-20)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,24 +66,24 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1778072014</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.7-1777857794</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.7-1778072020</ubi9-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1778735208</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1777876409</ubi9-micro.image.version>
+        <ubi9-minimal.image.version>9.8-1777460003</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
 
-        <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
+        <ubi9-minimal.openssl.version>3.5.5-2.el9_8</ubi9-minimal.openssl.version>
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
-        <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.3</ubi9-minimal.python3.version>
-        <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
+        <ubi9-minimal.nmap-ncat.version>7.92-5.el9</ubi9-minimal.nmap-ncat.version>
+        <ubi9-minimal.python3.version>3.9.25-7.el9_8</ubi9-minimal.python3.version>
+        <ubi9-minimal.tar.version>1.34-11.el9</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
-        <ubi9-minimal.krb5-workstation.version>1.21.1-9.el9_7</ubi9-minimal.krb5-workstation.version>
+        <ubi9-minimal.krb5-workstation.version>1.21.1-10.el9_8</ubi9-minimal.krb5-workstation.version>
         <ubi9-minimal.iputils.version>20210202-15.el9_7</ubi9-minimal.iputils.version>
         <ubi9-minimal.hostname.version>3.23-6.el9</ubi9-minimal.hostname.version>
         <ubi9-minimal.xz-libs.version>5.2.5-8.el9_0</ubi9-minimal.xz-libs.version>
-        <ubi9-minimal.glibc.version>2.34-231.el9_7.10</ubi9-minimal.glibc.version>
+        <ubi9-minimal.glibc.version>2.34-266.el9_8</ubi9-minimal.glibc.version>
         <ubi9-minimal.findutils.version>4.8.0-7.el9</ubi9-minimal.findutils.version>
-        <ubi9-minimal.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9-minimal.crypto-policies-scripts.version>
+        <ubi9-minimal.crypto-policies-scripts.version>20260224-1.gitea0f072.el9_8</ubi9-minimal.crypto-policies-scripts.version>
         <ubi9-minimal.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9-minimal.temurin-21-jdk.version>
         <ubi9-minimal.python3-pip.version>21.3.1-1.el9</ubi9-minimal.python3-pip.version>
 
@@ -93,7 +93,7 @@
         <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
-        <ubi8-minimal.krb5-workstation.version>1.18.2-33.el8_10</ubi8-minimal.krb5-workstation.version>
+        <ubi8-minimal.krb5-workstation.version>1.18.2-34.el8_10</ubi8-minimal.krb5-workstation.version>
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>
@@ -109,7 +109,7 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.171</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>v1.0.10</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.11</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.3-trixie</golang.image.version>


### PR DESCRIPTION
## Summary
Applies all dependency bumps from bot PR #1792 EXCEPT `git-repo.confluent-docker-utils.tag` (kept at `v0.0.171`).

Re-raises #1792 without the confluent-docker-utils tag bump that caused the CI failure.

## Test plan
- [x] CI checks pass