### PR TITLE
CPBR-3789 Re-apply Docker dependency update for 8.2.0-cp1-rc260602082747

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,25 +66,25 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1772599255</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.7-1771346390</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.7-1773204619</ubi9-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1779857793</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1779858820</ubi9-micro.image.version>
+        <ubi9-minimal.image.version>9.8-1780378819</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
-        <ubi9-minimal.openssl.version>3.5.1-7.el9_7</ubi9-minimal.openssl.version>
+        <ubi9-minimal.openssl.version>3.5.5-3.el9_8</ubi9-minimal.openssl.version>
         <ubi9-minimal.wget.version>1.21.1-8.el9_4</ubi9-minimal.wget.version>
-        <ubi9-minimal.nmap-ncat.version>7.92-3.el9</ubi9-minimal.nmap-ncat.version>
-        <ubi9-minimal.python3.version>3.9.25-3.el9_7.1</ubi9-minimal.python3.version>
-        <ubi9-minimal.tar.version>1.34-9.el9_7</ubi9-minimal.tar.version>
+        <ubi9-minimal.nmap-ncat.version>7.92-5.el9</ubi9-minimal.nmap-ncat.version>
+        <ubi9-minimal.python3.version>3.9.25-7.el9_8</ubi9-minimal.python3.version>
+        <ubi9-minimal.tar.version>1.34-11.el9</ubi9-minimal.tar.version>
         <ubi9-minimal.procps-ng.version>3.3.17-14.el9</ubi9-minimal.procps-ng.version>
-        <ubi9-minimal.krb5-workstation.version>1.21.1-8.el9_6</ubi9-minimal.krb5-workstation.version>
+        <ubi9-minimal.krb5-workstation.version>1.21.1-10.el9_8</ubi9-minimal.krb5-workstation.version>
         <ubi9-minimal.iputils.version>20210202-15.el9_7</ubi9-minimal.iputils.version>
         <ubi9-minimal.hostname.version>3.23-6.el9</ubi9-minimal.hostname.version>
         <ubi9-minimal.xz-libs.version>5.2.5-8.el9_0</ubi9-minimal.xz-libs.version>
-        <ubi9-minimal.glibc.version>2.34-231.el9_7.10</ubi9-minimal.glibc.version>
+        <ubi9-minimal.glibc.version>2.34-270.el9_8</ubi9-minimal.glibc.version>
         <ubi9-minimal.findutils.version>4.8.0-7.el9</ubi9-minimal.findutils.version>
-        <ubi9-minimal.crypto-policies-scripts.version>20250905-1.git377cc42.el9_7</ubi9-minimal.crypto-policies-scripts.version>
-        <ubi9-minimal.temurin-21-jdk.version>21.0.10.0.0.7-0</ubi9-minimal.temurin-21-jdk.version>
-        <ubi9-minimal.python3-pip.version>21.3.1-1.el9</ubi9-minimal.python3-pip.version>
+        <ubi9-minimal.crypto-policies-scripts.version>20260224-1.gitea0f072.el9_8</ubi9-minimal.crypto-policies-scripts.version>
+        <ubi9-minimal.temurin-21-jdk.version>21.0.11.0.0.10-0</ubi9-minimal.temurin-21-jdk.version>
+        <ubi9-minimal.python3-pip.version>21.3.1-2.el9_8</ubi9-minimal.python3-pip.version>
 
         <ubi8-minimal.openssl.version>1.1.1k-15.el8_6</ubi8-minimal.openssl.version>
         <ubi8-minimal.wget.version>1.19.5-12.el8_10</ubi8-minimal.wget.version>
@@ -92,26 +92,26 @@
         <ubi8-minimal.python39.version>3.9.25-2.module+el8.10.0+23718+1842ae33</ubi8-minimal.python39.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>
         <ubi8-minimal.procps-ng.version>3.3.15-14.el8</ubi8-minimal.procps-ng.version>
-        <ubi8-minimal.krb5-workstation.version>1.18.2-32.el8_10</ubi8-minimal.krb5-workstation.version>
+        <ubi8-minimal.krb5-workstation.version>1.18.2-34.el8_10</ubi8-minimal.krb5-workstation.version>
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>
-        <ubi8-minimal.glibc.version>2.28-251.el8_10.27</ubi8-minimal.glibc.version>
-        <ubi8-minimal.curl.version>7.61.1-34.el8_10.10</ubi8-minimal.curl.version>
+        <ubi8-minimal.glibc.version>2.28-251.el8_10.37</ubi8-minimal.glibc.version>
+        <ubi8-minimal.curl.version>7.61.1-34.el8_10.11</ubi8-minimal.curl.version>
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
-        <ubi8-minimal.temurin-17-jdk.version>17.0.18.0.0.8-0</ubi8-minimal.temurin-17-jdk.version>
+        <ubi8-minimal.temurin-17-jdk.version>17.0.19.0.0.10-0</ubi8-minimal.temurin-17-jdk.version>
         <ubi8-minimal.python39-pip.version>20.2.4-9.module+el8.10.0+21329+8d76b841</ubi8-minimal.python39-pip.version>
 
         <!-- Python Package Versions -->
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>v1.0.9</git-repo.cp-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.12</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
-        <golang.image.version>1.26.1-trixie</golang.image.version>
+        <golang.image.version>1.26.4-trixie</golang.image.version>
 
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check


### PR DESCRIPTION
Re-applies the dep bump from auto-update PR #1855 (cherry-pick of `593e5d72`), which the bot auto-closed + deleted its branch before it could land.

Why #1855 CI failed
- Build couldn't resolve parent POM `io.confluent:common:8.2.0-cp1`. The hotfix `common` artifact is published only to the rc staging S3 maven repo (`staging-confluent-packages-maven-…/v8.2.0-cp1-rc260602082747/maven`), but the PR build resolves from CodeArtifact / packages.confluent.io, where it is absent → `Non-resolvable parent POM … (absent)`.
- With CI red, the bot closed the PR and deleted its ephemeral branch, discarding the bump.

This PR
- Restores the identical `pom.xml` change on a persistent branch so it can be reviewed/merged
- Bumps: UBI8/UBI9 base + OS pkgs, confluent-docker-utils v0.0.172, cp-docker-utils v1.0.12, golang 1.26.4-trixie

Old PR: https://github.com/confluentinc/common-docker/pull/1855
JIRA: https://confluentinc.atlassian.net/browse/CPBR-3789