### PR TITLE
CPBR-3789 Keep confluent-docker-utils v0.0.169 for 8.2.0-cp1 hotfix (Python 3.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <python.setuptools.version>82.0.1</python.setuptools.version>
 
         <!-- GitHub Repository Tags -->
-        <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
+        <git-repo.confluent-docker-utils.tag>v0.0.169</git-repo.confluent-docker-utils.tag>
         <git-repo.cp-docker-utils.tag>v1.0.12</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->


### PR DESCRIPTION
Reverts the `confluent-docker-utils` tag bump (v0.0.172 → **v0.0.169**) on the 8.2.0-cp1 hotfix RC. Keeps the other dep bumps from #1856.

Why
- `confluent-docker-utils` **v0.0.172** requires `requests~=2.33.0`, which needs **Python ≥3.10**.
- The hotfix RC base image (`cp-base-new`) ships **Python 3.9**, so the build cannot resolve it:
  `ERROR: No matching distribution found for requests~=2.33.0` (max available 2.32.5).
- **v0.0.169** uses `requests~=2.32.0`, which is Python 3.9-compatible.

Decision
- Bumping Python 3.9→3.10 in a hotfix is too large/risky a change. Instead, keep the older `confluent-docker-utils` (older `requests`) for this hotfix.

Change
- `pom.xml`: `git-repo.confluent-docker-utils.tag` v0.0.172 → v0.0.169 (one line)

JIRA: https://confluentinc.atlassian.net/browse/CPBR-3789