### PR TITLE
CPBR-3846: base-java-micro: UB_DEFAULT_CLASSPATH so CUB_CLASSPATH is honored

### DIFF
--- a/base-java-micro/Dockerfile.ubi9
+++ b/base-java-micro/Dockerfile.ubi9
@@ -83,7 +83,7 @@ LABEL io.confluent.docker.git.repo="confluentinc/common-docker" \
 
 ENV LANG="C.UTF-8"
 ENV USE_LOG4J_2="True"
-ENV UB_CLASSPATH=/usr/share/java/cp-base-java-micro/*
+ENV UB_DEFAULT_CLASSPATH=/usr/share/java/cp-base-java-micro/*
 
 COPY --from=jdk-builder /microdir/ /
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>v1.0.12</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.13</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.4-trixie</golang.image.version>


### PR DESCRIPTION
## Problem

`cp-base-java-micro` bakes `ENV UB_CLASSPATH=/usr/share/java/cp-base-java-micro/*` so `ub` finds its jars. But that makes `UB_CLASSPATH` always non-empty at runtime, which short-circuits `ub`'s classpath fallback (`UB_CLASSPATH` → `CUB_CLASSPATH` → default) and **silently ignores a user-set `CUB_CLASSPATH`** on every micro image — a backward-compat regression. Non-micro `cp-base-java` is unaffected (it sets neither var).

## Change

- `base-java-micro/Dockerfile.ubi9`: `ENV UB_CLASSPATH=` → `ENV UB_DEFAULT_CLASSPATH=`. `ub` reads the per-image default from the new lowest-priority `UB_DEFAULT_CLASSPATH`, so the micro jar dir still applies by default while user `UB_CLASSPATH` / legacy `CUB_CLASSPATH` overrides win again.
- `pom.xml`: bump `git-repo.cp-docker-utils.tag` `v1.0.12` → `v1.0.13` (the `ub` release that adds `UB_DEFAULT_CLASSPATH`).
