### PR TITLE
[TEST - DO NOT MERGE] Bake ub listeners fix into cp-base-java (INC-11376)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>v1.0.13</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>fix-ub-listeners-cub-parity</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.4-trixie</golang.image.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>fix-ub-listeners-cub-parity</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>dc7b68602afd0213edca36ff514e7cdd33d60dd2</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.4-trixie</golang.image.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 
         <!-- GitHub Repository Tags -->
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
-        <git-repo.cp-docker-utils.tag>dc7b68602afd0213edca36ff514e7cdd33d60dd2</git-repo.cp-docker-utils.tag>
+        <git-repo.cp-docker-utils.tag>v1.0.15</git-repo.cp-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
         <golang.image.version>1.26.4-trixie</golang.image.version>


### PR DESCRIPTION
**Do not merge — CI validation only.**

**Why**
- Pre-merge validation of the `ub listeners` cub-parity fix (cp-docker-utils PR #21, branch `fix-ub-listeners-cub-parity`) for INC-11376, by baking it into `cp-base-java` and building the image chain.

**Change**
- `pom.xml`: `git-repo.cp-docker-utils.tag` `v1.0.13` → `fix-ub-listeners-cub-parity` (a git ref, so `go install …/cmd/ub@<ref>` compiles the fix into `/usr/bin/ub`).

**Revert before any real use**
- Must be repinned to the released tag (`v1.0.14`) once cp-docker-utils PR #21 merges. Branch pins are non-reproducible and test-only.

INC-11376 / cp-docker-utils#21