### PR TITLE
[TEST][DO NOT MERGE] Control: openssl bump on 7.8.x (gzip repro)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <ubi8-minimal.image.version>8.10-1780550539</ubi8-minimal.image.version>
 
         <!-- OS Package Versions -->
-        <ubi8-minimal.openssl.version>1.1.1k-15.el8_6</ubi8-minimal.openssl.version>
+        <ubi8-minimal.openssl.version>1.1.1k-16.el8_6</ubi8-minimal.openssl.version>
         <ubi8-minimal.wget.version>1.19.5-12.el8_10</ubi8-minimal.wget.version>
         <ubi8-minimal.nmap-ncat.version>7.92-2.el8_10</ubi8-minimal.nmap-ncat.version>
         <ubi8-minimal.tar.version>1.30-11.el8_10</ubi8-minimal.tar.version>


### PR DESCRIPTION
**Do not merge — diagnostic control test.**

Control for the 7.9.x experiment (#1955): same one-line `ubi8-minimal.openssl.version` `1.1.1k-15 → 1.1.1k-16` bump, on **7.8.x**.

- **Purpose:** check whether 7.8.x's `cp-base-new` ubi8 build *also* fails on `tar -xzf` / `gzip` when the build is perturbed — i.e., is 7.8.x identically broken to 7.9.x, or genuinely different?
- **Expected (hypothesis):** also fails with `gzip: Cannot exec` (same missing-gzip latent bug; 7.8.x has the identical Dockerfile).
- **Real fix (separate):** add `gzip` to `base/Dockerfile.ubi8`.
