### PR TITLE
Update Docker dependencies for 8.0.2-cp8-rc260629172233 (re-apply of #2014)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,14 +66,14 @@
         -->
 
         <!-- Base Image Versions -->
-        <ubi8-minimal.image.version>8.10-1779857793</ubi8-minimal.image.version>
-        <ubi9-micro.image.version>9.8-1779858820</ubi9-micro.image.version>
-        <ubi9-minimal.image.version>9.8-1779809423</ubi9-minimal.image.version>
+        <ubi8-minimal.image.version>8.10-1781701121</ubi8-minimal.image.version>
+        <ubi9-micro.image.version>9.8-1782363471</ubi9-micro.image.version>
+        <ubi9-minimal.image.version>9.8-1782708562</ubi9-minimal.image.version>
         <!-- OS Package Versions -->
 
-        <ubi9-minimal.openssl.version>3.5.5-2.el9_8</ubi9-minimal.openssl.version>
+        <ubi9-minimal.openssl.version>3.5.5-4.el9_8</ubi9-minimal.openssl.version>
         <!-- OpenSSL-libs version (must match openssl version exactly for FIPS compliance) -->
-        <ubi9-minimal.openssl-libs.version>3.5.5-2.el9_8</ubi9-minimal.openssl-libs.version>
+        <ubi9-minimal.openssl-libs.version>3.5.5-4.el9_8</ubi9-minimal.openssl-libs.version>
         <!-- OpenSSL version that is FIPS compliant (for source compilation in base image) -->
         <fips.openssl.version>3.1.2</fips.openssl.version>
         <!-- Redhat Package Versions -->
@@ -99,13 +99,13 @@
         <ubi8-minimal.iputils.version>20180629-11.el8</ubi8-minimal.iputils.version>
         <ubi8-minimal.hostname.version>3.20-6.el8</ubi8-minimal.hostname.version>
         <ubi8-minimal.xz-libs.version>5.2.4-4.el8_6</ubi8-minimal.xz-libs.version>
-        <ubi8-minimal.glibc.version>2.28-251.el8_10.37</ubi8-minimal.glibc.version>
+        <ubi8-minimal.glibc.version>2.28-251.el8_10.38</ubi8-minimal.glibc.version>
         <ubi8-minimal.curl.version>7.61.1-34.el8_10.11</ubi8-minimal.curl.version>
         <ubi8-minimal.findutils.version>4.6.0-24.el8_10</ubi8-minimal.findutils.version>
         <ubi8-minimal.crypto-policies-scripts.version>20230731-1.git3177e06.el8</ubi8-minimal.crypto-policies-scripts.version>
 
         <!-- Python Runtime Versions -->
-        <python-runtime.3-14.version>3.14.5</python-runtime.3-14.version>
+        <python-runtime.3-14.version>3.14.6</python-runtime.3-14.version>
 
         <!-- PyPI Package Versions -->
         <python.setuptools.version>82.0.1</python.setuptools.version>
@@ -114,7 +114,7 @@
         <git-repo.confluent-docker-utils.tag>v0.0.172</git-repo.confluent-docker-utils.tag>
 
         <!-- Docker Hub Image Versions -->
-        <golang.image.version>1.26.3-trixie</golang.image.version>
+        <golang.image.version>1.26.4-trixie</golang.image.version>
 
         <!-- In base/{pom.xml,Dockerfile.ubi} this property is used to to fail a build if the Yum/Dnf package manager
         detects that there is security update availible to be installed. Set to true if you want to skip the check


### PR DESCRIPTION
## Why
- RC branch `8.0.2-cp8-rc260629172233` image build fails: `No package matches 'openssl-3.5.5-2.el9_8'` (pinned RPM aged out of the UBI9 repo).
- The auto-generated Docker-dependency update PR #2014 carried the fix but was auto-closed after its CI run failed.

## Changes
- Cherry-pick of #2014 (commit `a46c16f`, `-x`): bump pinned versions in `pom.xml`.
  - `ubi9-minimal.openssl` / `openssl-libs`: `3.5.5-2.el9_8` → `3.5.5-4.el9_8` (fixes the build break).
  - ubi8/ubi9 base images, `ubi8 glibc`, `python-runtime 3.14.5→3.14.6`, `golang 1.26.3→1.26.4`.

## Notes
- #2014's CI failed at the version-set step (`pinto get-version` didn't recognise the RC branch; parent POM `io.confluent:common:pom:8.0.2-cp8` absent in CodeArtifact) — i.e. infra, not the diff. Re-raising to re-run CI now that the parent artifact should be available.