### PR TITLE
CPBR-3924, CPBR-3775, CPBR-3776 | Remove Sigstore Transitives from cp-base-new Image

### DIFF
--- a/base/Dockerfile.ubi8
+++ b/base/Dockerfile.ubi8
@@ -104,6 +104,7 @@ RUN microdnf --nodocs install yum \
     && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
     && python3.9 -m pip uninstall -y sigstore \
     && yum remove -y python39 python39-pip \
+    && rm -rf /usr/local/lib/python3.9/site-packages/* /usr/local/lib64/python3.9/site-packages/* \
     && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
     && tar -xzf Python-${PYTHON314_VERSION}.tgz \
     && cd Python-${PYTHON314_VERSION} \


### PR DESCRIPTION
### Change Description
Appsec scanners flagged `cryptography 46.0.7` and `urllib3 2.6.3` in `cp-base-new` image. Neither package is a declared dependency of this repo or of confluent-docker-utils.

**Root cause:** We install `sigstore` under Python 3.9 to verify the Python 3.14 source tarball, then run `pip uninstall -y sigstore` and `yum remove -y python39 python39-pip` but this does not cascade-remove transitives, and `yum remove` only removes yum-tracked files - pip-installed content under `/usr/local/lib{,64}/python3.9/site-packages/` (cryptography, urllib3, pyOpenSSL, pydantic, requests, etc.) persists in the final image as orphans. 

Runtime uses Python 3.14, whose `sys.path` never touches these directories, so the files are unused. This PR removes this unnecessary dependencies. To be pint merged upto 7.9.x

### Changes Made
- `base/Dockerfile.ubi8`: Added remove py3.9 packages command after the sigstore uninstall step

### Testing Done
Succesful Image Build: https://semaphore.ci.confluent.io/workflows/8adf793f-eeb2-4ed2-bd84-568d739d91e7?pipeline_id=fcebe9a9-b7d9-4adc-b4a7-7f613de489c0

Ref: https://confluentinc.atlassian.net/browse/CPBR-3924, https://confluentinc.atlassian.net/browse/CPBR-3775, https://confluentinc.atlassian.net/browse/CPBR-3776

