### PR TITLE
CPBR-3924, CPBR-3775, CPBR-3776 | Remove Sigstore Transitives from cp-base-new Image

### DIFF
--- a/base/Dockerfile.ubi9
+++ b/base/Dockerfile.ubi9
@@ -106,6 +106,7 @@ RUN microdnf --nodocs -y install yum \
     && rm -f Python-${PYTHON314_VERSION}.tgz.sigstore \
     && python3 -m pip uninstall -y sigstore \
     && yum remove -y python3-pip \
+    && rm -rf /usr/local/lib/python3.9/site-packages/* /usr/local/lib64/python3.9/site-packages/* \
     && rm -f /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.9 \
     && tar -xzf Python-${PYTHON314_VERSION}.tgz \
     && cd Python-${PYTHON314_VERSION} \


### PR DESCRIPTION
### Change Description
Appsec scanners flagged `cryptography 46.0.7` and `urllib3 2.6.3` in `cp-base-new` image. Neither package is a declared dependency of this repo or of confluent-docker-utils.

**Root cause:** We install `sigstore` under Python 3.9 to verify the Python 3.14 source tarball, then run `pip uninstall -y sigstore` and `yum remove -y python39 python39-pip` but this does not cascade-remove transitives, and `yum remove` only removes yum-tracked files - pip-installed content under `/usr/local/lib{,64}/python3.9/site-packages/` (cryptography, urllib3, pyOpenSSL, pydantic, requests, etc.) persists in the final image as orphans. 

Runtime uses Python 3.14, whose `sys.path` never touches these directories, so the files are unused. This PR removes this unnecessary dependencies.

### Changes Made
- `base/Dockerfile.ubi8`: Added remove py3.9 packages command after the sigstore uninstall step

### Testing Done
Succesful Image Build: https://semaphore.ci.confluent.io/workflows/ebd6a5d7-18de-4b25-86b6-1a7f7e56c65f?pipeline_id=0ed328b5-1005-434a-943f-2f6fc75f995f