### PR TITLE
Pin jmx_prometheus_javaagent to explicit 1.3.0 instead of inherited common version

### DIFF
--- a/base-java-micro/pom.xml
+++ b/base-java-micro/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx_prometheus_javaagent.version}</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx_prometheus_javaagent.version}</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Why
- `base-java` and `base-java-micro` both inherit `jmx_prometheus_javaagent.version` (currently `0.20.0`) from the `common` parent POM
- Pinning explicitly to `1.3.0` decouples this upgrade from a `common` release and avoids the much older inherited baseline

## Changes
- `base-java/pom.xml`: replace `${jmx_prometheus_javaagent.version}` with explicit `1.3.0`
- `base-java-micro/pom.xml`: same change

## Notes
- `1.3.0` was chosen over `1.2.0` (the next version after `0.20.0`) because `1.2.0`'s released jar embeds a Maven POM with a `<parent>` reference to `io.prometheus.jmx:jmx_exporter:1.2.0`, which was never published to Maven Central or CodeArtifact — this breaks downstream dependency resolution
- Confirmed via a CodeArtifact mirror-and-resolve dry run (CPBR-3841) that `1.2.0` fails resolution with exactly this missing-parent error, while `1.3.0` (whose jar has no embedded POM, so Maven generates a synthetic one) uploads and resolves cleanly end-to-end (validated in a real Semaphore run)