### PR TITLE
Pin jmx_prometheus_javaagent to explicit 1.3.0 and 1.5.0 instead of inherited common version

### DIFF
--- a/base-java-micro/pom.xml
+++ b/base-java-micro/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>

--- a/base-java-micro/pom.xml
+++ b/base-java-micro/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx_prometheus_javaagent.version}</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>${jmx_prometheus_javaagent.version}</version>
+            <version>1.3.0</version>
         </dependency>
 
         <dependency>

--- a/base-java/pom.xml
+++ b/base-java/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>io.prometheus.jmx</groupId>
             <artifactId>jmx_prometheus_javaagent</artifactId>
-            <version>1.3.0</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Why
- `base-java` and `base-java-micro` both inherit `jmx_prometheus_javaagent.version` (currently `0.20.0`) from the `common` parent POM
- Pinning explicitly to `1.5.0` decouples this upgrade from a `common` release and avoids the much older inherited baseline

## Changes
- `base-java/pom.xml`: replace `${jmx_prometheus_javaagent.version}` with explicit `1.5.0`
- `base-java-micro/pom.xml`: same change

