### PR TITLE
CPBR-3961 | Fix Local Image Build Command in base-java Readmes

### DIFF
--- a/base-java-micro/Readme.md
+++ b/base-java-micro/Readme.md
@@ -49,8 +49,10 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn clean package -Pdocker -DskipTests # Build local images
+mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
+
+`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `docker-fabric8` profile instead, which pins it correctly.
 
 ## License
 

--- a/base-java-micro/Readme.md
+++ b/base-java-micro/Readme.md
@@ -52,7 +52,7 @@ To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies
 mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
 
-`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `docker-fabric8` profile instead, which pins it correctly.
+The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so the build passes without producing any image. `docker-fabric8` binds it to the `package` phase.
 
 ## License
 

--- a/base-java/README.md
+++ b/base-java/README.md
@@ -35,8 +35,10 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn clean package -Pdocker -DskipTests # Build local images
+mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean install dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY # Build local images
 ```
+
+`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `jenkins,docker-fabric8` profile combination CI actually uses (see [`.semaphore/semaphore.yml`](../.semaphore/semaphore.yml)).
 
 ## License
 

--- a/base-java/README.md
+++ b/base-java/README.md
@@ -35,7 +35,7 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean install dependency:analyze validate -U -Ddocker.registry=$DOCKER_DEV_REGISTRY # Build local images
+mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean install dependency:analyze validate -U # Build local images, uses the placeholder/ registry by default
 ```
 
 `-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `jenkins,docker-fabric8` profile combination CI actually uses (see [`.semaphore/semaphore.yml`](../.semaphore/semaphore.yml)).

--- a/base-java/README.md
+++ b/base-java/README.md
@@ -35,10 +35,10 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn -Dmaven.wagon.http.retryHandler.count=3 --batch-mode -P jenkins,docker-fabric8 clean install dependency:analyze validate -U # Build local images, uses the placeholder/ registry by default
+mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
 
-`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `jenkins,docker-fabric8` profile combination CI actually uses (see [`.semaphore/semaphore.yml`](../.semaphore/semaphore.yml)).
+`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `docker-fabric8` profile instead, which pins it correctly.
 
 ## License
 

--- a/base-java/README.md
+++ b/base-java/README.md
@@ -38,7 +38,7 @@ To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies
 mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
 
-`-Pdocker` alone doesn't pin the `io.fabric8:docker-maven-plugin` version, so Maven hangs trying to resolve it. Use the `docker-fabric8` profile instead, which pins it correctly.
+The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so the build passes without producing any image. `docker-fabric8` binds it to the `package` phase.
 
 ## License
 


### PR DESCRIPTION
### Change Description

This PR updates the local image build command in `base-java/README.md` and `base-java-micro/Readme.md` to use the `docker-fabric8` profile. Previously the documented command reports `BUILD SUCCESS` while building nothing, because `-Pdocker` leaves `io.fabric8:docker-maven-plugin` unbound and `base-java` no longer declares the Spotify plugin that profile drives.

**Note:** the earlier reasoning on this PR blamed plugin version resolution. That was an expired CodeArtifact token locally, unrelated to the readme.

### Testing

Both run on `master`, starting with no `placeholder/confluentinc/*` images.
<img width="1673" height="866" alt="image" src="https://github.com/user-attachments/assets/0b8b8473-2f6c-4fae-b92d-8d7407009c05" />


`mvn clean package -Pdocker -DskipTests` — passes in 18s, no image built:
<img width="1141" height="458" alt="image" src="https://github.com/user-attachments/assets/6eae6831-3b45-49f4-9602-510a9bf10881" />
<img width="1116" height="370" alt="image" src="https://github.com/user-attachments/assets/a0b22e25-ba76-48e9-bae8-cadb044d8ab8" />

<img width="1312" height="232" alt="image" src="https://github.com/user-attachments/assets/fb985089-b9dc-45d5-953a-c70078d55b2e" />


`mvn clean package -P docker-fabric8 -DskipTests` — passes in 2m58s, tags all three at `8.4.0-0-ubi9`:

<img width="1306" height="475" alt="image" src="https://github.com/user-attachments/assets/8ce12e05-1ced-4fcf-96bf-9474b25de80c" />
<img width="1411" height="368" alt="image" src="https://github.com/user-attachments/assets/192e3fb2-b3cb-48c9-84f0-5ba3f3ed3430" />

<img width="1201" height="339" alt="image" src="https://github.com/user-attachments/assets/5b3ccbe9-725b-433f-af87-347fa41450ec" />

Cross verified in a `linux/amd64` maven container and against an empty `m2` repo.

Ref: https://confluentinc.atlassian.net/browse/CPBR-3961
