### PR TITLE
CPBR-3987 | Fix Utility-Belt Build for Relocated AK dependencies

### DIFF
--- a/utility-belt/pom.xml
+++ b/utility-belt/pom.xml
@@ -138,6 +138,14 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-codec-standalone</artifactId>
             <version>${apacheda.version}</version>

--- a/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
+++ b/utility-belt/src/test/java/io/confluent/admin/utils/EmbeddedKafkaCluster.java
@@ -15,14 +15,14 @@
  */
 package io.confluent.admin.utils;
 
-import kafka.security.JaasTestUtils;
-import kafka.security.minikdc.MiniKdc;
 import kafka.server.KafkaBroker;
 import kafka.utils.TestUtils;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.security.JaasTestUtils;
+import org.apache.kafka.security.minikdc.MiniKdc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import scala.Option;


### PR DESCRIPTION
### Change Description
AK moved the `kafka.security` package from `core` to the `server` module in https://github.com/apache/kafka/pull/21407. CCS-Kafka mirror also has this new change because of this the utility belt breaks when it tries to find the packages that moved. This PR updates the dependencies and UB according to the updated AK code.

Previous failing build pointing to error: https://semaphore.ci.confluent.io/jobs/24be4024-62de-4439-91f8-69ef2ec39ff1#L1147

8.3.x/4.3.x and below don't have this change, where Scala classes still exist thus we need to make this change on master.

Ref: https://confluentinc.atlassian.net/browse/CPBR-3987

### Testing
Succesful Image Build: https://semaphore.ci.confluent.io/workflows/f08ce8c6-dbad-40f1-a7db-c40f13f6c0b6?pipeline_id=7eabe7eb-e45e-4d38-a89b-e1cabc5f166f
