### PR TITLE
CPBR-3961 | Fix Broken Local Docker Build Command in base-java README

### DIFF
--- a/base-java/README.md
+++ b/base-java/README.md
@@ -35,8 +35,10 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn clean package -Pdocker -DskipTests # Build local images
+mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
+
+The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so the build passes without producing any image. `docker-fabric8` binds it to the `package` phase.
 
 ## License
 


### PR DESCRIPTION
### Description
This PR replaces `-Pdocker` with `-P docker-fabric8` in `base-java/README.md`'s local build command. The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so `mvn clean package -Pdocker -DskipTests` completes without producing an image.

Same change as https://github.com/confluentinc/common-docker/pull/2154, which landed on master first. Raising from 8.0.x instead because this is a per-image README. `base-java/` exists on 8.0.x through master and on no 7.x branch (7.x has `base/` and `base-lite/`), so 8.0.x is the floor. 8.0.x, 8.1.x, 8.2.x and 8.3.x all carry the broken command, so this should pint merge up to 8.3.x and stop there.

`base-java-micro/Readme.md` has the same problem but only exists on 8.3.x, so that is a separate PR.

### Testing
Docs only, no build impact. The replacement command was verified locally under #2154.