### PR TITLE
CPBR-3961 | Fix Broken Local Docker Build Command in base-java-micro README

### DIFF
--- a/base-java-micro/Readme.md
+++ b/base-java-micro/Readme.md
@@ -49,8 +49,10 @@ This project uses `maven-assembly-plugin` and `dockerfile-maven-plugin` to build
 To build SNAPSHOT images, configure `.m2/settings.xml` for SNAPSHOT dependencies. These must be available at build time.
 
 ```
-mvn clean package -Pdocker -DskipTests # Build local images
+mvn clean package -P docker-fabric8 -DskipTests # Build local images
 ```
+
+The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so the build passes without producing any image. `docker-fabric8` binds it to the `package` phase.
 
 ## License
 


### PR DESCRIPTION
### Description
This PR replaces `-Pdocker` with `-P docker-fabric8` in `base-java-micro/Readme.md`'s local build command. The `docker` profile leaves `io.fabric8:docker-maven-plugin` unbound, so `mvn clean package -Pdocker -DskipTests` completes without producing an image.

Same change as https://github.com/confluentinc/common-docker/pull/2154, which landed on master first. Raising from 8.3.x because `base-java-micro/` was introduced there and exists on no earlier branch, so nothing merges up into it from the `base-java` fix in https://github.com/confluentinc/common-docker/pull/2255. Nothing to pint merge past 8.3.x since master already has it.

### Testing
Docs only, no build impact. The replacement command was verified locally under #2154.